### PR TITLE
Align Transform2D structure with Transform3D

### DIFF
--- a/examples/dodge-the-creeps-2d/rust/src/gameplay/mob.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/gameplay/mob.rs
@@ -99,7 +99,7 @@ fn spawn_mob(
     commands
         .spawn_empty()
         .insert(Mob { direction })
-        .insert(Transform2D(transform))
+        .insert(Transform2D::from(transform))
         .insert(GodotScene::from_resource(assets.mob_scn.clone()));
 }
 

--- a/examples/dodge-the-creeps-2d/rust/src/gameplay/player.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/gameplay/player.rs
@@ -113,7 +113,7 @@ fn setup_player(
             .unwrap()
             .get::<Node2D>()
             .get_position();
-        transform.origin = start_position;
+        transform.as_godot_mut().origin = start_position;
     }
 
     Ok(())
@@ -162,9 +162,9 @@ fn move_player(
             sprite.stop();
         }
 
-        transform.origin += velocity * system_delta.delta_seconds();
-        transform.origin.x = f32::min(f32::max(0.0, transform.origin.x), screen_size.x);
-        transform.origin.y = f32::min(f32::max(0.0, transform.origin.y), screen_size.y);
+        transform.as_godot_mut().origin += velocity * system_delta.delta_seconds();
+        transform.as_godot_mut().origin.x = f32::min(f32::max(0.0, transform.as_godot().origin.x), screen_size.x);
+        transform.as_godot_mut().origin.y = f32::min(f32::max(0.0, transform.as_godot().origin.y), screen_size.y);
     }
 
     Ok(())

--- a/godot-bevy/src/plugins/core/scene_tree.rs
+++ b/godot-bevy/src/plugins/core/scene_tree.rs
@@ -212,7 +212,7 @@ fn create_scene_tree_entity(
                 if let Some(node2d) = node.try_get::<Node2D>() {
                     // TODO: validate this is as expected
                     let transform = node2d.get_transform();
-                    ent.insert(Transform2D(transform));
+                    ent.insert(Transform2D::from(transform));
                 }
 
                 let mut node = node.get::<Node>();

--- a/godot-bevy/src/plugins/packed_scene.rs
+++ b/godot-bevy/src/plugins/packed_scene.rs
@@ -136,15 +136,15 @@ fn spawn_scene(
             match transform {
                 GodotSceneTransform::Transform2D(transform) => {
                     match instance.clone().try_cast::<Node2D>().ok() {
-                        Some(mut node2d) => node2d.set_global_transform(*transform),
+                        Some(mut node2d) => node2d.set_global_transform(*transform.as_godot()),
                         None => tracing::error!(
-                            "attempted to spawn a scene with a transform on Node that did not inherit from Node3D, the transform was not set"
+                            "attempted to spawn a scene with a transform on Node that did not inherit from Node2D, the transform was not set"
                         ),
                     }
                 }
                 GodotSceneTransform::Transform3D(transform) => {
                     match instance.clone().try_cast::<Node3D>().ok() {
-                        Some(mut node3d) => node3d.set_global_transform(*transform),
+                        Some(mut node3d) => node3d.set_global_transform(*transform.as_godot()),
                         None => tracing::error!(
                             "attempted to spawn a scene with a transform on Node that did not inherit from Node3D, the transform was not set"
                         ),


### PR DESCRIPTION
Resolves issue #3 by implementing a dual-structure pattern for Transform2D
that matches Transform3D, ensuring consistency across both transform types.

Changes:
- Transform2D now has both Bevy and Godot transform fields (like Transform3D)
- Added conversion traits: IntoBevyTransform2D and IntoGodotTransform2D
- Implemented Transform2D methods: IDENTITY, translated(), as_bevy(), as_godot(), etc.
- Extended TransformMutGuard system to support Transform2D with proper generics
- Updated all usage sites to use new constructor pattern and accessor methods
- Fixed packed_scene.rs to use transform.as_godot() for proper dereferencing
- Updated example files (mob.rs, player.rs) to use new Transform2D API

Benefits:
- Consistent API between Transform2D and Transform3D
- Type-safe access patterns with automatic synchronization
- Eliminates direct tuple field access in favor of proper methods
- Maintains backwards compatibility through From trait implementations

Created by GitHub Copilot Agent