### PR TITLE
fix the position of spawn_mob in doge the creeps example

### DIFF
--- a/examples/dodge-the-creeps-2d/rust/src/gameplay/mob.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/gameplay/mob.rs
@@ -93,7 +93,7 @@ fn spawn_mob(
 
     let position = mob_spawn_location.get_position();
     let transform = GodotTransform2D::IDENTITY.translated(position);
-    let transform = transform.rotated(direction);
+    let transform = transform.rotated_local(direction);
 
     commands
         .spawn_empty()


### PR DESCRIPTION
The original implementation is rotated with global (0, 0). So should rotate first, then translate.

I change the code to rotate with the mob's (0, 0)