### PR TITLE
Add repository and "Suggest an Edit" links to book for easier cross-documentation navigation

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -4,3 +4,7 @@ language = "en"
 multilingual = false
 src = "src"
 title = "The godot-bevy Book 👾"
+
+[output.html]
+git-repository-url = "https://github.com/bytemeadow/godot-bevy"
+edit-url-template = "https://github.com/bytemeadow/godot-bevy/edit/main/book/{path}"


### PR DESCRIPTION
When reading the book, I often found myself wishing for a link to take me from the book to other documentation sources such as the GitHub repo and rust api docs.

This PR adds two links to the top-right corner of the book. The first is a link to the project's GitHub page, the second is a "Suggest an Edit" link that navigates to a GitHub online editor for the specified book page.