### PR TITLE
fix: rename godot_main_thread to main_thread_system

### DIFF
--- a/book/src/threading/main-thread-access.md
+++ b/book/src/threading/main-thread-access.md
@@ -13,14 +13,14 @@ Any system that interacts with Godot APIs—such as calling methods on `Node`, a
 - Input handling via Godot's `Input` singleton
 - File I/O operations through Godot's resource system
 
-## The `#[godot_main_thread]` Macro
+## The `#[main_thread_system]` Macro
 
-The `#[godot_main_thread]` attribute macro provides a clean way to mark systems that require main thread execution:
+The `#[main_thread_system]` attribute macro provides a clean way to mark systems that require main thread execution:
 
 ```rust
 use godot_bevy::prelude::*;
 
-#[godot_main_thread]
+#[main_thread_system]
 fn update_ui_labels(
     mut query: Query<&mut GodotNodeHandle, With<PlayerStats>>,
     stats: Res<GameStats>,
@@ -37,7 +37,7 @@ The macro automatically adds a `NonSend<MainThreadMarker>` parameter to the syst
 
 ## Best Practices: Minimize Systems That Call Godot APIs
 
-While the `#[godot_main_thread]` macro makes Godot API access convenient, systems assigned to the main thread cannot execute in parallel with other main thread-assigned systems. This can become a performance bottleneck in complex applications, as all systems requiring Godot API access must wait their turn to execute sequentially on this single thread.
+While the `#[main_thread_system]` macro makes Godot API access convenient, systems assigned to the main thread cannot execute in parallel with other main thread-assigned systems. This can become a performance bottleneck in complex applications, as all systems requiring Godot API access must wait their turn to execute sequentially on this single thread.
 
 ### Recommended Architecture
 

--- a/examples/boids-perf-test/rust/src/bevy_boids.rs
+++ b/examples/boids-perf-test/rust/src/bevy_boids.rs
@@ -134,7 +134,7 @@ fn load_assets(mut commands: Commands, server: Res<AssetServer>) {
 }
 
 /// Synchronize parameters from the container to Bevy resources
-#[godot_main_thread]
+#[main_thread_system]
 fn sync_container_params(
     mut boid_count: ResMut<BoidCount>,
     mut config: ResMut<BoidsConfig>,
@@ -259,7 +259,7 @@ fn despawn_boids(
 }
 
 /// Update simulation state and manage cleanup on stop
-#[godot_main_thread]
+#[main_thread_system]
 fn stop_simulation(
     simulation_state: Res<SimulationState>,
     mut commands: Commands,
@@ -279,7 +279,7 @@ fn stop_simulation(
 }
 
 /// Colorize newly spawned boids (matches GDScript behavior)
-#[godot_main_thread]
+#[main_thread_system]
 fn colorize_new_boids(
     mut commands: Commands,
     new_boids: Query<(Entity, &GodotNodeHandle), With<NeedsColorization>>,
@@ -333,7 +333,7 @@ fn sync_transforms(mut query: Query<(&Transform2D, &mut Transform), With<Boid>>)
 // system to calculate/store neighborhood forces
 // NOTE: While this doesn't _need_ to be on the main thread, we see a
 // significant performance impact (75 -> 53 fps drop) when not on main
-#[godot_main_thread]
+#[main_thread_system]
 fn boids_calculate_neighborhood_forces(
     spatial_tree: Res<BoidTree>,
     all_boids: Query<(&Transform, &Velocity), With<Boid>>,

--- a/examples/dodge-the-creeps-2d/rust/src/commands.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/commands.rs
@@ -166,7 +166,7 @@ impl Plugin for CommandSystemPlugin {
 }
 
 /// Main thread system that processes UI commands
-#[godot_main_thread]
+#[main_thread_system]
 fn process_ui_commands(mut ui_commands: EventReader<UICommand>, ui_handles: Res<UIHandles>) {
     use godot::classes::{Button, Label};
 
@@ -198,7 +198,7 @@ fn process_ui_commands(mut ui_commands: EventReader<UICommand>, ui_handles: Res<
 }
 
 /// Main thread system that processes node commands
-#[godot_main_thread]
+#[main_thread_system]
 fn process_node_commands(
     mut node_commands: EventReader<NodeCommand>,
     mut nodes: Query<&mut GodotNodeHandle>,
@@ -235,7 +235,7 @@ fn process_node_commands(
 }
 
 /// Main thread system that processes animation commands
-#[godot_main_thread]
+#[main_thread_system]
 fn process_animation_commands(
     mut animation_commands: EventReader<AnimationCommand>,
     mut nodes: Query<&mut GodotNodeHandle>,
@@ -266,7 +266,7 @@ fn process_animation_commands(
 }
 
 /// Main thread system that syncs visibility state to Godot nodes
-#[godot_main_thread]
+#[main_thread_system]
 fn sync_visibility_state(
     mut nodes: Query<(&mut GodotNodeHandle, &mut VisibilityState), Changed<VisibilityState>>,
 ) {
@@ -283,7 +283,7 @@ fn sync_visibility_state(
 }
 
 /// Main thread system that syncs animation state to Godot sprites
-#[godot_main_thread]
+#[main_thread_system]
 fn sync_animation_state(
     mut nodes: Query<(&mut GodotNodeHandle, &mut AnimationState), Changed<AnimationState>>,
 ) {

--- a/examples/dodge-the-creeps-2d/rust/src/gameplay/audio.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/gameplay/audio.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use bevy::state::state::{OnEnter, OnExit};
 use bevy_asset_loader::asset_collection::AssetCollection;
 use godot_bevy::prelude::{
-    godot_main_thread, AudioApp, AudioChannel, AudioChannelMarker, GodotResource,
+    main_thread_system, AudioApp, AudioChannel, AudioChannelMarker, GodotResource,
 };
 
 use crate::GameState;
@@ -48,7 +48,7 @@ pub struct GameAudio {
 }
 
 /// System that starts background music
-#[godot_main_thread]
+#[main_thread_system]
 fn start_background_music(
     music_channel: Res<AudioChannel<GameMusicChannel>>,
     game_audio: Res<GameAudio>,
@@ -63,14 +63,14 @@ fn start_background_music(
 }
 
 /// System that stops background music
-#[godot_main_thread]
+#[main_thread_system]
 fn stop_background_music(music_channel: Res<AudioChannel<GameMusicChannel>>) {
     music_channel.stop();
     info!("Stopped background music");
 }
 
 /// System that plays game over sound
-#[godot_main_thread]
+#[main_thread_system]
 fn play_game_over_sound(
     sfx_channel: Res<AudioChannel<GameSfxChannel>>,
     game_audio: Res<GameAudio>,

--- a/examples/dodge-the-creeps-2d/rust/src/gameplay/mob.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/gameplay/mob.rs
@@ -23,7 +23,7 @@ use godot::{
 use godot_bevy::{
     bridge::GodotNodeHandle,
     prelude::{
-        godot_main_thread, AudioChannel, FindEntityByNameExt, GodotResource, GodotScene,
+        main_thread_system, AudioChannel, FindEntityByNameExt, GodotResource, GodotScene,
         GodotSignal, GodotSignals, NodeTreeView, Transform2D,
     },
 };
@@ -67,7 +67,7 @@ pub struct Mob {
 #[derive(Resource)]
 pub struct MobSpawnTimer(Timer);
 
-#[godot_main_thread]
+#[main_thread_system]
 fn spawn_mob(
     mut commands: Commands,
     time: Res<Time>,
@@ -116,7 +116,7 @@ pub struct MobNodes {
     visibility_notifier: GodotNodeHandle,
 }
 
-#[godot_main_thread]
+#[main_thread_system]
 fn new_mob(
     mut entities: Query<
         (
@@ -172,7 +172,7 @@ fn new_mob(
     }
 }
 
-#[godot_main_thread]
+#[main_thread_system]
 fn kill_mob(mut signals: EventReader<GodotSignal>, _node_commands: EventWriter<NodeCommand>) {
     for signal in signals.read() {
         if signal.name == "screen_exited" {

--- a/examples/dodge-the-creeps-2d/rust/src/gameplay/player.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/gameplay/player.rs
@@ -7,7 +7,7 @@ use godot::{
 };
 use godot_bevy::{
     plugins::core::PhysicsDelta,
-    prelude::{godot_main_thread, *},
+    prelude::{main_thread_system, *},
 };
 
 use crate::{
@@ -58,7 +58,7 @@ fn spawn_player(mut commands: Commands, assets: Res<PlayerAssets>) {
         .insert(Player { speed: 0.0 });
 }
 
-#[godot_main_thread]
+#[main_thread_system]
 fn player_on_ready(
     mut commands: Commands,
     mut player: Query<
@@ -86,7 +86,7 @@ fn player_on_ready(
     Ok(())
 }
 
-#[godot_main_thread]
+#[main_thread_system]
 fn setup_player(
     mut player: Query<(Entity, &mut VisibilityState, &mut Transform2D), With<Player>>,
     mut entities: Query<(&Name, &mut GodotNodeHandle), Without<Player>>,
@@ -108,7 +108,7 @@ fn setup_player(
     Ok(())
 }
 
-#[godot_main_thread]
+#[main_thread_system]
 fn move_player(
     mut player: Query<(
         &Player,
@@ -165,7 +165,7 @@ fn move_player(
     Ok(())
 }
 
-#[godot_main_thread]
+#[main_thread_system]
 fn check_player_death(
     mut player: Query<(&mut VisibilityState, &Collisions), With<Player>>,
     mut next_state: ResMut<NextState<GameState>>,

--- a/examples/dodge-the-creeps-2d/rust/src/main_menu.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/main_menu.rs
@@ -13,7 +13,7 @@ use bevy::{
 };
 use godot_bevy::{
     bridge::GodotNodeHandle,
-    prelude::{godot_main_thread, GodotSignal, GodotSignals, NodeTreeView, SceneTreeRef},
+    prelude::{main_thread_system, GodotSignal, GodotSignals, NodeTreeView, SceneTreeRef},
 };
 
 use crate::{
@@ -59,7 +59,7 @@ pub struct MenuUi {
     pub score_label: GodotNodeHandle,
 }
 
-#[godot_main_thread]
+#[main_thread_system]
 fn init_menu_assets(
     mut menu_assets: ResMut<MenuAssets>,
     mut ui_handles: ResMut<UIHandles>,

--- a/examples/platformer-2d/rust/src/gameplay/gem.rs
+++ b/examples/platformer-2d/rust/src/gameplay/gem.rs
@@ -60,7 +60,7 @@ impl Plugin for GemPlugin {
 ///
 /// This system only handles collision detection and event firing,
 /// allowing it to run independently of gem counting logic.
-#[godot_main_thread]
+#[main_thread_system]
 fn detect_gem_player_collision(
     mut gems: Query<(Entity, &mut GodotNodeHandle, &Collisions), With<Gem>>,
     players: Query<Entity, With<Player>>,

--- a/examples/platformer-2d/rust/src/gameplay/hud.rs
+++ b/examples/platformer-2d/rust/src/gameplay/hud.rs
@@ -67,7 +67,7 @@ impl Plugin for HudPlugin {
 /// System to set up HUD handles and update displays when a new level is loaded
 ///
 /// Simplified approach that still reduces SceneTreeRef conflicts by batching operations.
-#[godot_main_thread]
+#[main_thread_system]
 fn setup_hud_on_level_loaded(
     mut hud_handles: ResMut<HudHandles>,
     mut events: EventReader<LevelLoadedEvent>,
@@ -112,7 +112,7 @@ fn generate_hud_update_events(
 ///
 /// This system can run in parallel with other incremental update systems
 /// since it only responds to events and updates UI elements.
-#[godot_main_thread]
+#[main_thread_system]
 fn handle_hud_update_events(
     mut hud_events: EventReader<HudUpdateEvent>,
     hud_handles: Res<HudHandles>,

--- a/examples/platformer-2d/rust/src/gameplay/player.rs
+++ b/examples/platformer-2d/rust/src/gameplay/player.rs
@@ -92,7 +92,7 @@ impl Plugin for PlayerPlugin {
 ///
 /// Runs in InputDetection set and can execute in parallel with other input systems.
 /// Only reads input and writes events, enabling better parallelization.
-#[godot_main_thread]
+#[main_thread_system]
 fn detect_player_input(
     mut player: Query<&mut GodotNodeHandle, With<Player>>,
     mut input_events: EventWriter<PlayerInputEvent>,
@@ -122,7 +122,7 @@ fn detect_player_input(
 ///
 /// Runs in Movement set after input detection. Handles all physics calculations
 /// and movement execution separately from input detection.
-#[godot_main_thread]
+#[main_thread_system]
 fn apply_player_movement(
     mut input_events: EventReader<PlayerInputEvent>,
     mut player: Query<(&mut GodotNodeHandle, &Speed, &JumpVelocity, &Gravity), With<Player>>,
@@ -188,7 +188,7 @@ fn apply_player_movement(
 ///
 /// Runs in Animation set after movement. Handles all animation state
 /// separately from physics and input.
-#[godot_main_thread]
+#[main_thread_system]
 fn update_player_animation(
     mut movement_events: EventReader<PlayerMovementEvent>,
     mut player: Query<&mut GodotNodeHandle, With<Player>>,

--- a/examples/platformer-2d/rust/src/main_menu.rs
+++ b/examples/platformer-2d/rust/src/main_menu.rs
@@ -66,7 +66,7 @@ fn reset_menu_assets(mut menu_assets: ResMut<MenuAssets>) {
     menu_assets.signals_connected = false;
 }
 
-#[godot_main_thread]
+#[main_thread_system]
 fn init_menu_assets(mut menu_assets: ResMut<MenuAssets>, mut scene_tree: SceneTreeRef) {
     // Try to find menu nodes, but handle failure gracefully
     if let Some(root) = scene_tree.get().get_root() {
@@ -123,7 +123,7 @@ fn connect_buttons(mut menu_assets: ResMut<MenuAssets>, signals: GodotSignals) {
     }
 }
 
-#[godot_main_thread]
+#[main_thread_system]
 fn listen_for_button_press(
     menu_assets: Res<MenuAssets>,
     mut events: EventReader<GodotSignal>,

--- a/examples/platformer-2d/rust/src/scene_management.rs
+++ b/examples/platformer-2d/rust/src/scene_management.rs
@@ -32,7 +32,7 @@ impl Plugin for SceneManagementPlugin {
 /// Central system that processes scene tree operations
 ///
 /// This system reduces SceneTreeRef conflicts by handling scene operations centrally.
-#[godot_main_thread]
+#[main_thread_system]
 fn process_scene_operations(
     mut scene_tree: SceneTreeRef,
     mut operation_events: EventReader<SceneOperationEvent>,

--- a/godot-bevy-macros/src/lib.rs
+++ b/godot-bevy-macros/src/lib.rs
@@ -10,13 +10,13 @@ use syn::{
 /// Attribute macro that ensures a system runs on the main thread by adding a NonSend<MainThreadMarker> parameter.
 /// This is required for systems that need to access Godot APIs.
 #[proc_macro_attribute]
-pub fn godot_main_thread(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn main_thread_system(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut input_fn = parse_macro_input!(item as syn::ItemFn);
     let fn_name = &input_fn.sig.ident;
 
     // Create a unique type alias name for this function
     let type_alias_name = syn::Ident::new(
-        &format!("__GodotMainThreadMarker_{fn_name}"),
+        &format!("__MainThreadSystemMarker_{fn_name}"),
         fn_name.span(),
     );
 

--- a/godot-bevy/src/plugins/audio/plugin.rs
+++ b/godot-bevy/src/plugins/audio/plugin.rs
@@ -6,7 +6,7 @@ use crate::plugins::audio::{
     AudioSettings, ChannelId, ChannelState, MainAudioTrack, PlayCommand, SoundId, TweenType,
 };
 use crate::plugins::core::SceneTreeRef;
-use crate::prelude::godot_main_thread;
+use crate::prelude::main_thread_system;
 use bevy::app::{App, Plugin, Update};
 use bevy::asset::Assets;
 use bevy::ecs::system::ResMut;
@@ -351,7 +351,7 @@ fn start_audio_playback(handle: &mut GodotNodeHandle) {
 }
 
 /// System that cleans up finished sounds
-#[godot_main_thread]
+#[main_thread_system]
 fn cleanup_finished_sounds(mut audio_output: ResMut<AudioOutput>) {
     let mut finished_sounds = Vec::new();
 
@@ -399,7 +399,7 @@ fn remove_and_free_audio_node(handle: &mut GodotNodeHandle) {
 }
 
 /// System that updates active audio tweens
-#[godot_main_thread]
+#[main_thread_system]
 fn update_audio_tweens(mut audio_output: ResMut<AudioOutput>, time: Res<Time>) {
     let delta = time.delta();
     let mut completed_tweens = Vec::new();

--- a/godot-bevy/src/plugins/core/scene_tree.rs
+++ b/godot-bevy/src/plugins/core/scene_tree.rs
@@ -1,7 +1,7 @@
 use super::collisions::ALL_COLLISION_SIGNALS;
 use super::node_markers::*;
 use super::{GodotTransformConfig, TransformSyncMode};
-use crate::prelude::godot_main_thread;
+use crate::prelude::main_thread_system;
 use crate::prelude::{Transform2D, Transform3D};
 use crate::{bridge::GodotNodeHandle, prelude::Collisions};
 use bevy::ecs::system::Res;
@@ -78,7 +78,7 @@ impl Default for SceneTreeRefImpl {
     }
 }
 
-#[godot_main_thread]
+#[main_thread_system]
 pub fn initialize_scene_tree(
     mut commands: Commands,
     mut scene_tree: SceneTreeRef,
@@ -125,7 +125,7 @@ pub enum SceneTreeEventType {
     NodeRenamed,
 }
 
-#[godot_main_thread]
+#[main_thread_system]
 fn connect_scene_tree(mut scene_tree: SceneTreeRef) {
     let mut scene_tree_gd = scene_tree.get();
 
@@ -460,7 +460,7 @@ fn create_scene_tree_entity(
     }
 }
 
-#[godot_main_thread]
+#[main_thread_system]
 fn read_scene_tree_events(
     mut commands: Commands,
     mut scene_tree: SceneTreeRef,

--- a/godot-bevy/src/plugins/core/transforms.rs
+++ b/godot-bevy/src/plugins/core/transforms.rs
@@ -14,7 +14,7 @@ use godot::classes::{Node2D, Node3D};
 use godot::prelude::Transform3D as GodotTransform3D;
 
 use crate::bridge::GodotNodeHandle;
-use crate::prelude::godot_main_thread;
+use crate::prelude::main_thread_system;
 
 use super::{Node2DMarker, Node3DMarker};
 
@@ -332,7 +332,7 @@ impl Plugin for GodotTransformsPlugin {
     }
 }
 
-#[godot_main_thread]
+#[main_thread_system]
 fn post_update_godot_transforms_3d(
     config: Res<super::GodotTransformConfig>,
     mut entities: Query<
@@ -357,7 +357,7 @@ fn post_update_godot_transforms_3d(
     }
 }
 
-#[godot_main_thread]
+#[main_thread_system]
 fn pre_update_godot_transforms_3d(
     config: Res<super::GodotTransformConfig>,
     mut entities: Query<(&mut Transform3D, &mut GodotNodeHandle), With<Node3DMarker>>,
@@ -380,7 +380,7 @@ fn pre_update_godot_transforms_3d(
     }
 }
 
-#[godot_main_thread]
+#[main_thread_system]
 fn post_update_godot_transforms_2d(
     config: Res<super::GodotTransformConfig>,
     mut entities: Query<
@@ -409,7 +409,7 @@ fn post_update_godot_transforms_2d(
     }
 }
 
-#[godot_main_thread]
+#[main_thread_system]
 fn pre_update_godot_transforms_2d(
     config: Res<super::GodotTransformConfig>,
     mut entities: Query<(&mut Transform2D, &mut GodotNodeHandle), With<Node2DMarker>>,

--- a/godot-bevy/src/plugins/packed_scene.rs
+++ b/godot-bevy/src/plugins/packed_scene.rs
@@ -1,7 +1,7 @@
 use super::core::{SceneTreeRef, Transform2D, Transform3D};
 use crate::bridge::GodotNodeHandle;
 use crate::plugins::assets::GodotResource;
-use crate::prelude::godot_main_thread;
+use crate::prelude::main_thread_system;
 use bevy::{
     app::{App, Plugin, PostUpdate},
     asset::{Assets, Handle},
@@ -69,7 +69,7 @@ impl GodotScene {
 #[derive(Component, Debug, Default)]
 struct GodotSceneSpawned;
 
-#[godot_main_thread]
+#[main_thread_system]
 fn spawn_scene(
     mut commands: Commands,
     mut new_scenes: Query<


### PR DESCRIPTION
I believe this name is more true to what is actually occurring than `godot_main_thread`. While Godot is the reason we added this: to make it easier to interact with Godot APIs that require the main thread.. what this macro does is ensure that the system runs on the main thread which has in itself not necessarily anything to do with Godot.