### PR TITLE
fix: add safety to get_parent() in scene tree parser

### DIFF
--- a/godot-bevy/src/plugins/core/scene_tree.rs
+++ b/godot-bevy/src/plugins/core/scene_tree.rs
@@ -442,6 +442,10 @@ fn create_scene_tree_entity(
                         let parent_id = parent.instance_id();
                         if let Some(&parent_entity) = ent_mapping.get(&parent_id) {
                             commands.entity(parent_entity).add_children(&[ent]);
+                        } else {
+                            bevy::log::warn!(target: "godot_scene_tree_events", 
+                                "Parent entity with ID {} not found in ent_mapping. This might indicate a missing or incorrect mapping.", 
+                                parent_id);
                         }
                     }
                 }


### PR DESCRIPTION
In testing scenarios, nodes can be created without proper parent-child relationships in the scene tree, causing `get_parent()` to return `None`. 