### PR TITLE
feat: support multi field bevy bundle

### DIFF
--- a/godot-bevy-macros/src/lib.rs
+++ b/godot-bevy-macros/src/lib.rs
@@ -437,7 +437,7 @@ fn bevy_bundle(input: DeriveInput) -> Result<TokenStream2> {
                         }
                     } else {
                         quote! {
-                            #field_ident: #component_name(node.bind().#source_field)
+                            #field_ident: #component_name(node.bind().#source_field.clone())
                         }
                     }
                 }
@@ -453,7 +453,7 @@ fn bevy_bundle(input: DeriveInput) -> Result<TokenStream2> {
                                 }
                             } else {
                                 quote! {
-                                    #bevy_field: node.bind().#godot_field
+                                    #bevy_field: node.bind().#godot_field.clone()
                                 }
                             }
                         })


### PR DESCRIPTION
Allows for doing something like:
```rust
#[derive(GodotClass, BevyBundle)]
#[class(base=Node3D)]
#[bevy_bundle((VolcanoVent {
    autostart: autostart,
    delay_start: delay_start,
    spawn_pattern: spawn_pattern with String::from
}))]
```