### PR TITLE
fix(transform): don’t constrain pre_updates to main

### DIFF
--- a/godot-bevy/src/plugins/transforms/sync_systems.rs
+++ b/godot-bevy/src/plugins/transforms/sync_systems.rs
@@ -36,7 +36,6 @@ pub fn post_update_godot_transforms_3d(
     }
 }
 
-#[main_thread_system]
 pub fn pre_update_godot_transforms_3d(
     config: Res<crate::plugins::core::GodotTransformConfig>,
     mut entities: Query<(&mut Transform3D, &mut GodotNodeHandle), With<Node3DMarker>>,
@@ -90,7 +89,6 @@ pub fn post_update_godot_transforms_2d(
     }
 }
 
-#[main_thread_system]
 pub fn pre_update_godot_transforms_2d(
     config: Res<crate::plugins::core::GodotTransformConfig>,
     mut entities: Query<(&mut Transform2D, &mut GodotNodeHandle), With<Node2DMarker>>,


### PR DESCRIPTION
`pre_update_` methods are being unnecessarily constrained to main thread