### PR TITLE
fix(scene_tree): remove from ent_mapping when removing a node

### DIFF
--- a/godot-bevy/src/plugins/scene_tree/plugin.rs
+++ b/godot-bevy/src/plugins/scene_tree/plugin.rs
@@ -528,6 +528,7 @@ fn create_scene_tree_entity(
             SceneTreeEventType::NodeRemoved => {
                 if let Some(ent) = ent {
                     commands.entity(ent).despawn();
+                    ent_mapping.remove(&node.instance_id());
                 } else {
                     // Entity was already despawned (common when using queue_free)
                     trace!(target: "godot_scene_tree_events", "Entity for removed node was already despawned");


### PR DESCRIPTION
This fixes #84 and cases where in quick succession we may get a remove entity and add entity in quick succession. where it'll try to reuse what's on the map already. 