### PR TITLE
fix(transform): check transforms change before setting

### DIFF
--- a/godot-bevy/src/plugins/transforms/sync_systems.rs
+++ b/godot-bevy/src/plugins/transforms/sync_systems.rs
@@ -30,7 +30,7 @@ pub fn pre_update_godot_transforms_3d(
     for (mut bevy_transform, mut reference) in entities.iter_mut() {
         let godot_transform = reference.get::<Node3D>().get_transform();
         let new_bevy_transform = godot_transform.to_bevy_transform();
-        
+
         // Only write if actually different - avoids triggering change detection
         if *bevy_transform != new_bevy_transform {
             *bevy_transform = new_bevy_transform;
@@ -61,7 +61,7 @@ pub fn pre_update_godot_transforms_2d(
     for (mut bevy_transform, mut reference) in entities.iter_mut() {
         let godot_transform = reference.get::<Node2D>().get_transform();
         let new_bevy_transform = godot_transform.to_bevy_transform();
-        
+
         // Only write if actually different - avoids triggering change detection
         if *bevy_transform != new_bevy_transform {
             *bevy_transform = new_bevy_transform;


### PR DESCRIPTION
Fixes #89 - our post sync already checks for changed transforms. However, in a two way sync, we read godot transforms in `pre` and use it to set the transform (which means it changes). This change makes sure we only update our internal transform if we read a different one from Godot. 