### PR TITLE
fix(Collisions): Move collision processing to physics_process

### DIFF
--- a/godot-bevy/src/app.rs
+++ b/godot-bevy/src/app.rs
@@ -2,6 +2,7 @@ use bevy::app::App;
 use godot::prelude::*;
 use std::sync::{Mutex, mpsc::channel};
 
+use crate::plugins::core::PrePhysicsUpdate;
 use crate::watchers::collision_watcher::CollisionWatcher;
 use crate::watchers::input_watcher::GodotInputWatcher;
 use crate::watchers::scene_tree_watcher::SceneTreeWatcher;
@@ -134,6 +135,7 @@ impl INode for BevyApp {
                 app.world_mut().resource_mut::<PhysicsDelta>().delta_seconds = delta;
 
                 // Run only our physics-specific schedule
+                app.world_mut().run_schedule(PrePhysicsUpdate);
                 app.world_mut().run_schedule(PhysicsUpdate);
             })) {
                 self.app = None;

--- a/godot-bevy/src/plugins/collisions.rs
+++ b/godot-bevy/src/plugins/collisions.rs
@@ -1,5 +1,7 @@
+use crate::interop::GodotNodeHandle;
+use crate::plugins::core::PrePhysicsUpdate;
 use bevy::{
-    app::{App, First, Plugin, PreUpdate},
+    app::{App, Plugin},
     ecs::{
         component::Component,
         entity::Entity,
@@ -11,8 +13,6 @@ use bevy::{
 };
 use godot::prelude::*;
 use std::sync::mpsc::Receiver;
-
-use crate::interop::GodotNodeHandle;
 
 #[derive(Default)]
 pub struct GodotCollisionsPlugin;
@@ -38,12 +38,14 @@ pub struct CollisionEvent {
 
 impl Plugin for GodotCollisionsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(PreUpdate, update_godot_collisions)
-            .add_systems(
-                First,
+        app.add_systems(
+            PrePhysicsUpdate,
+            (
                 write_godot_collision_events.before(event_update_system),
-            )
-            .add_event::<CollisionEvent>();
+                update_godot_collisions,
+            ),
+        )
+        .add_event::<CollisionEvent>();
     }
 }
 

--- a/godot-bevy/src/plugins/core.rs
+++ b/godot-bevy/src/plugins/core.rs
@@ -13,6 +13,11 @@ use std::marker::PhantomData;
 use std::time::{Duration, Instant};
 
 /// Schedule that runs during Godot's physics_process at physics frame rate.
+/// This schedule runs just before the PhysicsUpdate schedule.
+#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct PrePhysicsUpdate;
+
+/// Schedule that runs during Godot's physics_process at physics frame rate.
 /// Use this for movement, physics, and systems that need to sync with Godot's physics timing.
 #[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PhysicsUpdate;
@@ -253,6 +258,7 @@ impl Plugin for GodotBaseCorePlugin {
             .init_resource::<SceneTreeComponentRegistry>();
 
         // Add the PhysicsUpdate schedule
+        app.add_schedule(Schedule::new(PrePhysicsUpdate));
         app.add_schedule(Schedule::new(PhysicsUpdate));
     }
 }


### PR DESCRIPTION
- Allows Godot-Bevy collision processing to happen in the same physics frame as the Godot collision signal.
- Fixes dropped collision events when nodes are queue_free'd in their body_entered signal handler.

Fixes https://github.com/bytemeadow/godot-bevy/issues/95