### PR TITLE
Adding Two way syncing demo (example)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4264,6 +4264,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
+name = "two-way-sync-demo"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "godot",
+ "godot-bevy",
+ "which 8.0.0",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,15 @@ license = "MIT OR Apache-2.0"
 
 [workspace]
 members = [
-    "godot-bevy",
-    "examples/avian-physics-demo/rust",
-    "examples/dodge-the-creeps-2d/rust",
-    "examples/timing-test/rust",
-    "examples/input-event-demo/rust",
-    "examples/platformer-2d/rust",
-    "examples/simple-node2d-movement/rust",
-    "examples/boids-perf-test/rust",
+  "godot-bevy",
+  "examples/avian-physics-demo/rust",
+  "examples/dodge-the-creeps-2d/rust",
+  "examples/timing-test/rust",
+  "examples/input-event-demo/rust",
+  "examples/platformer-2d/rust",
+  "examples/simple-node2d-movement/rust",
+  "examples/boids-perf-test/rust",
+  "examples/two-way-sync-demo/rust",
 ]
 resolver = "2"
 

--- a/examples/two-way-sync-demo/README.md
+++ b/examples/two-way-sync-demo/README.md
@@ -1,0 +1,24 @@
+# Two way transform syncing demo
+
+This example demonstrates a Godot Node's x-position getting updated every frame
+in GDScript, while the same game object's Transform is accessed via godot-bevy
+where it's y-position is similarly updated every frame. While you wouldn't do
+this in a real game, this contrived example demonstrates that you have the
+flexibility to read and write the same game object's Transform either in Godot
+or Bevy.
+
+## What You'll See
+
+A quad rotating in a circular motion on screen.
+
+## Running This Example
+
+1. **Build**: `cargo build`
+2. **Run**: You can either:
+   1. Open the Godot project and run the scene
+   1. Run: `cargo run`. NOTE: This requires the Godot binary, which we attempt
+      to locate either through your environment's path or by searching common
+      locations. If this doesn't work, update your path to include Godot. If
+      this fails for other reasons, it may be because your version of Godot
+      is different than the one the example was built with, in that case,
+      try opening the Godot project first.

--- a/examples/two-way-sync-demo/godot/.editorconfig
+++ b/examples/two-way-sync-demo/godot/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+charset = utf-8

--- a/examples/two-way-sync-demo/godot/.gitattributes
+++ b/examples/two-way-sync-demo/godot/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize EOL for all files that Git considers text files.
+* text=auto eol=lf

--- a/examples/two-way-sync-demo/godot/.gitignore
+++ b/examples/two-way-sync-demo/godot/.gitignore
@@ -1,0 +1,3 @@
+# Godot 4+ specific ignores
+.godot/
+/android/

--- a/examples/two-way-sync-demo/godot/bevy_app_singleton.tscn
+++ b/examples/two-way-sync-demo/godot/bevy_app_singleton.tscn
@@ -1,0 +1,3 @@
+[gd_scene format=3 uid="uid://bullwnohqxwmu"]
+
+[node name="BevyAppSingleton" type="BevyApp"]

--- a/examples/two-way-sync-demo/godot/main.tscn
+++ b/examples/two-way-sync-demo/godot/main.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=3 uid="uid://by3mlw6lgl61y"]
+
+[ext_resource type="Script" uid="uid://dbrmkkj7y1fpl" path="res://quad.gd" id="1_ig7tw"]
+
+[sub_resource type="QuadMesh" id="QuadMesh_ig7tw"]
+
+[node name="Node" type="Node2D"]
+
+[node name="Camera2D" type="Camera2D" parent="."]
+
+[node name="Quad" type="MeshInstance2D" parent="."]
+scale = Vector2(25, 25)
+mesh = SubResource("QuadMesh_ig7tw")
+script = ExtResource("1_ig7tw")

--- a/examples/two-way-sync-demo/godot/project.godot
+++ b/examples/two-way-sync-demo/godot/project.godot
@@ -1,0 +1,30 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="Two Way Sync Demo"
+run/main_scene="uid://by3mlw6lgl61y"
+config/features=PackedStringArray("4.4", "GL Compatibility")
+
+[autoload]
+
+BevyAppSingleton="*res://bevy_app_singleton.tscn"
+
+[display]
+
+window/size/viewport_width=600
+window/size/viewport_height=600
+window/stretch/mode="viewport"
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"
+renderer/rendering_method.mobile="gl_compatibility"

--- a/examples/two-way-sync-demo/godot/quad.gd
+++ b/examples/two-way-sync-demo/godot/quad.gd
@@ -1,0 +1,6 @@
+extends MeshInstance2D
+
+func _process(delta):
+	# Notice that we only change the x coordinate here. The y coordinate is
+	# also updated every frame, except it's done in godot bevy, see lib.rs
+	position.x = sin(Engine.get_frames_drawn() / 50.) * 100.

--- a/examples/two-way-sync-demo/godot/quad.gd.uid
+++ b/examples/two-way-sync-demo/godot/quad.gd.uid
@@ -1,0 +1,1 @@
+uid://dbrmkkj7y1fpl

--- a/examples/two-way-sync-demo/godot/rust.gdextension
+++ b/examples/two-way-sync-demo/godot/rust.gdextension
@@ -1,0 +1,13 @@
+[configuration]
+entry_symbol = "gdext_rust_init"
+compatibility_minimum = 4.1
+
+[libraries]
+linux.debug.x86_64 = "res://../../../target/debug/libtwo_way_sync_demo.so"
+linux.release.x86_64 = "res://../../../target/release/libtwo_way_sync_demo.so"
+macos.debug.x86_64 = "res://../../../target/debug/libtwo_way_sync_demo.dylib"
+macos.release.x86_64 = "res://../../../target/release/libtwo_way_sync_demo.dylib"
+macos.debug.arm64 = "res://../../../target/debug/libtwo_way_sync_demo.dylib"
+macos.release.arm64 = "res://../../../target/release/libtwo_way_sync_demo.dylib"
+windows.debug.x86_64 = "res://../../../target/debug/two_way_sync_demo.dll"
+windows.release.x86_64 = "res://../../../target/release/two_way_sync_demo.dll"

--- a/examples/two-way-sync-demo/godot/rust.gdextension.uid
+++ b/examples/two-way-sync-demo/godot/rust.gdextension.uid
@@ -1,0 +1,1 @@
+uid://i7ue0rjasl88

--- a/examples/two-way-sync-demo/rust/Cargo.toml
+++ b/examples/two-way-sync-demo/rust/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "two-way-sync-demo"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[[bin]]
+path = "../../run_godot.rs"
+name = "two-way-sync-demo"
+
+[dependencies]
+godot-bevy = { path = "../../../godot-bevy" }
+bevy = { version = "0.16", default-features = false }
+godot = "0.3"
+which = "8"

--- a/examples/two-way-sync-demo/rust/src/lib.rs
+++ b/examples/two-way-sync-demo/rust/src/lib.rs
@@ -1,0 +1,33 @@
+#![allow(clippy::type_complexity)]
+
+use bevy::app::Update;
+use bevy::ecs::query::{Changed, With};
+use bevy::ecs::system::Query;
+use bevy::prelude::App;
+use bevy::utils::default;
+use bevy::{math::ops::cos, transform::components::Transform};
+use godot::classes::Engine;
+use godot_bevy::prelude::MeshInstance2DMarker;
+use godot_bevy::prelude::godot_prelude::ExtensionLibrary;
+use godot_bevy::prelude::godot_prelude::gdextension;
+use godot_bevy::prelude::{GodotTransformSyncPlugin, TransformSyncMode, bevy_app};
+
+#[bevy_app]
+fn build_app(app: &mut App) {
+    app.add_plugins(GodotTransformSyncPlugin {
+        sync_mode: TransformSyncMode::TwoWay,
+        ..default()
+    });
+
+    app.add_systems(Update, update_quad_y_position);
+}
+
+fn update_quad_y_position(
+    mut query: Query<&mut Transform, (With<MeshInstance2DMarker>, Changed<Transform>)>,
+) {
+    for mut transform in query.iter_mut() {
+        // Notice that we only change the y coordinate here. The x coordinate is
+        // also updated every frame, except it's done in GDScript, see quad.gd
+        transform.translation.y = cos(Engine::singleton().get_frames_drawn() as f32 / 50.) * 100.;
+    }
+}

--- a/godot-bevy/Cargo.toml
+++ b/godot-bevy/Cargo.toml
@@ -11,11 +11,11 @@ license.workspace = true
 
 [dependencies]
 bevy = { version = "0.16", default-features = false, features = [
-    "bevy_asset",
-    "bevy_state",
-    "bevy_log",
-    "bevy_gilrs",
-    "multi_threaded",
+  "bevy_asset",
+  "bevy_state",
+  "bevy_log",
+  "bevy_gilrs",
+  "multi_threaded",
 ] }
 godot = { version = "0.3.0", features = ["experimental-threads"] }
 godot-bevy-macros.workspace = true


### PR DESCRIPTION
This example demonstrates a Godot Node's x-position getting updated every frame in GDScript, while the same game object's Transform is accessed via godot-bevy where it's y-position is similarly updated every frame. While you wouldn't do this in a real game, this contrived example demonstrates that you have the flexibility to read and write the same game object's Transform either in Godot or Bevy.