### PR TITLE
Add GodotBevyLogPlugin: Improved logging by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
+checksum = "09f7e37c0ed80b2a977691c47dae8625cfb21e205827106c64f7c588766b2e50"
 dependencies = [
  "async-lock",
  "blocking",
@@ -1363,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.9.3"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+checksum = "441473f2b4b0459a68628c744bc61d23e730fb00128b841d30fa4bb3972257e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1406,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -1515,9 +1515,9 @@ checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
 
 [[package]]
 name = "const_panic"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2459fc9262a1aa204eb4b5764ad4f189caec88aea9634389c0a25f8be7f6265e"
+checksum = "b98d1483e98c9d67f341ab4b3915cfdc54740bd6f5cccc9226ee0535d86aa8fb"
 
 [[package]]
 name = "const_soft_float"
@@ -2137,9 +2137,9 @@ dependencies = [
 
 [[package]]
 name = "godot"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c4b80a6697ab47cbe03beaa519b4f40fc408ee43b853842224d5d4bdeb85ad"
+checksum = "bf88bc5c641a412f8098695546790e13d8e1c0b2ec6556356e2c6f47f8d80c91"
 dependencies = [
  "godot-core",
  "godot-macros",
@@ -2173,24 +2173,24 @@ dependencies = [
 
 [[package]]
 name = "godot-bindings"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ef8e3a3873c1c442b66da8ad939d12ab3ba2bb8c929bc9d45ae4d46047dbd4"
+checksum = "7b232ed5a858d55c7d450fd532e46dcfdc5616e7f7a31b77a39abf56acf55837"
 dependencies = [
  "gdextension-api",
 ]
 
 [[package]]
 name = "godot-cell"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e792bd37ca9b374ab70293bf1b62c17083048938773e9fe527fa844ba411c27"
+checksum = "c30a71a51456c7a190cfa01ad4c21700bb03df24dd41edb4c632c23e0306407c"
 
 [[package]]
 name = "godot-codegen"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1af2c1cf73ea183c4d6b3344259da3de41bf76df17227fa4c3fa309eecceb0d"
+checksum = "5970685601c06be9fc7f53c0560bda1c813d81604b748dbf057e4db22b788e0f"
 dependencies = [
  "godot-bindings",
  "heck",
@@ -2202,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "godot-core"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fb24e8689e236c80ad7580f87491c90a7f5f6fba8ea6f41863993d5b2b5b8f"
+checksum = "ea7fa55d72449795e32dc3c115efbbe2b6a4fb7fd5336bd8b27985e4731baa59"
 dependencies = [
  "glam 0.30.4",
  "godot-bindings",
@@ -2215,9 +2215,9 @@ dependencies = [
 
 [[package]]
 name = "godot-ffi"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f6f4fbcd1be7bae4c4e781c727317e68879afa1a6e33cd412160bc17e42827"
+checksum = "56ed673789ef833491f717074ccd9a5dde987760e56b872f6d63094d52d616a1"
 dependencies = [
  "godot-bindings",
  "godot-codegen",
@@ -2227,9 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "godot-macros"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b32a375c5a9852de4201751dbc650a39609c8f618c0a2c156958fd9fe6148e4"
+checksum = "b2e3396be9600ee93a3457628ad021fe5e6c0940b4ace5067ef92d5f448931cf"
 dependencies = [
  "godot-bindings",
  "proc-macro2",
@@ -2567,9 +2567,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leafwing-input-manager"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5921290ac62f78a4f2f2f9fe3a31c73bbf4309b013bf25f91514ac111e3976"
+checksum = "68ac3ba8262c0e42b22bb917c18ef9dbe773e2b6b279c61a4a520c5d960b5e1a"
 dependencies = [
  "bevy",
  "dyn-clone",
@@ -2617,13 +2617,13 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
- "redox_syscall 0.5.13",
+ "redox_syscall 0.5.15",
 ]
 
 [[package]]
@@ -2715,9 +2715,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
 dependencies = [
  "libc",
 ]
@@ -3285,7 +3285,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.13",
+ "redox_syscall 0.5.15",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3401,17 +3401,16 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
-version = "3.8.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
+checksum = "8ee9b2fa7a4517d2c91ff5bc6c297a427a96749d15f98fcdbb22c05571a4d4b7"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.0.7",
- "tracing",
- "windows-sys 0.59.0",
+ "rustix 1.0.8",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3641,9 +3640,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -3818,15 +3817,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4675,7 +4674,7 @@ checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "winsafe",
 ]
 
@@ -4686,7 +4685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "winsafe",
 ]
 
@@ -5169,9 +5168,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -5212,9 +5211,9 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
+checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
 
 [[package]]
 name = "yazi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_log-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,6 +1443,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,6 +2150,7 @@ name = "godot-bevy"
 version = "0.8.4"
 dependencies = [
  "bevy",
+ "chrono",
  "futures-lite",
  "godot",
  "godot-bevy-macros",
@@ -2353,6 +2374,30 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "image"

--- a/book/src/getting-started/plugins.md
+++ b/book/src/getting-started/plugins.md
@@ -20,7 +20,6 @@ All other features must be explicitly added as plugins.
   - Includes:
     - `GodotBaseCorePlugin`: Bevy MinimalPlugins, logging, diagnostics, schedules
     - `GodotSceneTreePlugin`: Scene tree entity mirroring and management
-    - `GodotBevyLogPlugin`: Unify/improve bevy and godot logging such that `info!`, `debug!`, etc log messages are visible in the Godot Editor
 
 - **`GodotDefaultPlugins`**: Contains all plugins typically necessary for building a game
   - Includes:
@@ -31,6 +30,7 @@ All other features must be explicitly added as plugins.
     - `BevyInputBridgePlugin`: Bevy input API support
     - `GodotAudioPlugin`: Audio system
     - `GodotPackedScenePlugin`: Runtime scene spawning
+    - `GodotBevyLogPlugin`: Unify/improve bevy and godot logging such that `info!`, `debug!`, etc log messages are visible in the Godot Editor
 
 ## Available Plugins
 
@@ -51,14 +51,6 @@ All other features must be explicitly added as plugins.
   - Transform component addition (configurable)
   - AutoSync bundle registration
   - Groups component for Godot groups
-
-- **`GodotBevyLogPlugin`**: Improved logging by default
-
-  - Log message components are color-coded for readability by default. Color coding can be disabled entirely. NOTE: There is a performance penalty for color-coding, so if your application is very performance sensitive, consider disabling this feature
-  - Log messages are prefixed with a short timestamp, e.g., `12:00:36.196`. Timestamps can be customized or entirely disabled
-  - Log messages are prefixed with a short log level, e.g., `T` for `TRACE`, `D` for `DEBUG`, `I` for `INFO`, `W` for `WARN`, `E` for `ERROR`
-  - Log messages are suffixed with a shortened path and line number location, e.g., `@ loading_state/systems.rs:186`
-  - Log level filtering is `INFO` and higher severity by default, this can be customized directly in your code or set at runtime using `RUST_LOG`, e.g., `RUST_LOG=trace cargo run`
 
 ### Additional Plugins
 
@@ -106,9 +98,18 @@ All other features must be explicitly added as plugins.
   - Integrates with Godot's audio engine
 
 - **`GodotPackedScenePlugin`**: Scene spawning
+
   - Spawn/instantiate scenes at runtime
   - Support for both asset handles and paths
   - Automatic transform application
+
+- **`GodotBevyLogPlugin`**: Improved logging by default
+
+  - Log message components are color-coded for readability by default. Color coding can be disabled entirely. NOTE: There is a performance penalty for color-coding, so if your application is very performance sensitive, consider disabling this feature
+  - Log messages are prefixed with a short timestamp, e.g., `12:00:36.196`. Timestamps can be customized or entirely disabled
+  - Log messages are prefixed with a short log level, e.g., `T` for `TRACE`, `D` for `DEBUG`, `I` for `INFO`, `W` for `WARN`, `E` for `ERROR`
+  - Log messages are suffixed with a shortened path and line number location, e.g., `@ loading_state/systems.rs:186`
+  - Log level filtering is `INFO` and higher severity by default, this can be customized directly in your code or set at runtime using `RUST_LOG`, e.g., `RUST_LOG=trace cargo run`
 
 ## Usage Examples
 

--- a/book/src/getting-started/plugins.md
+++ b/book/src/getting-started/plugins.md
@@ -54,7 +54,7 @@ All other features must be explicitly added as plugins.
 
 - **`GodotBevyLogPlugin`**: Improved logging by default
 
-  - Log message components are color-coded for readability by default. Color coding can be disabled entirely. NOTE: There is a performance penality for color-coding, so if your application is very performance sensitive, consider disabling this feature
+  - Log message components are color-coded for readability by default. Color coding can be disabled entirely. NOTE: There is a performance penalty for color-coding, so if your application is very performance sensitive, consider disabling this feature
   - Log messages are prefixed with a short timestamp, e.g., `12:00:36.196`. Timestamps can be customized or entirely disabled
   - Log messages are prefixed with a short log level, e.g., `T` for `TRACE`, `D` for `DEBUG`, `I` for `INFO`, `W` for `WARN`, `E` for `ERROR`
   - Log messages are suffixed with a shortened path and line number location, e.g., `@ loading_state/systems.rs:186`

--- a/book/src/getting-started/plugins.md
+++ b/book/src/getting-started/plugins.md
@@ -15,10 +15,12 @@ All other features must be explicitly added as plugins.
 ## Plugin Groups
 
 - **`GodotCorePlugins`**: Minimal required functionality
+
   - Automatically included by `#[bevy_app]` macro via `GodotPlugin`
   - Includes:
     - `GodotBaseCorePlugin`: Bevy MinimalPlugins, logging, diagnostics, schedules
     - `GodotSceneTreePlugin`: Scene tree entity mirroring and management
+    - `GodotBevyLogPlugin`: Unify/improve bevy and godot logging such that `info!`, `debug!`, etc log messages are visible in the Godot Editor
 
 - **`GodotDefaultPlugins`**: Contains all plugins typically necessary for building a game
   - Includes:
@@ -35,6 +37,7 @@ All other features must be explicitly added as plugins.
 ### Core Infrastructure (Included by Default)
 
 - **`GodotBaseCorePlugin`**: Foundation setup
+
   - Bevy MinimalPlugins (without ScheduleRunnerPlugin)
   - Asset system with Godot resource reader
   - Logging and diagnostics
@@ -42,45 +45,61 @@ All other features must be explicitly added as plugins.
   - Main thread marker resource
 
 - **`GodotSceneTreePlugin`**: Scene tree management
+
   - Automatic entity creation for scene nodes
   - Scene tree change monitoring
   - Transform component addition (configurable)
   - AutoSync bundle registration
   - Groups component for Godot groups
 
+- **`GodotBevyLogPlugin`**: Improved logging by default
+
+  - Log message components are color-coded for readability by default. Color coding can be disabled entirely. NOTE: There is a performance penality for color-coding, so if your application is very performance sensitive, consider disabling this feature
+  - Log messages are prefixed with a short timestamp, e.g., `12:00:36.196`. Timestamps can be customized or entirely disabled
+  - Log messages are prefixed with a short log level, e.g., `T` for `TRACE`, `D` for `DEBUG`, `I` for `INFO`, `W` for `WARN`, `E` for `ERROR`
+  - Log messages are suffixed with a shortened path and line number location, e.g., `@ loading_state/systems.rs:186`
+  - Log level filtering is `INFO` and higher severity by default, this can be customized directly in your code or set at runtime using `RUST_LOG`, e.g., `RUST_LOG=trace cargo run`
+
 ### Additional Plugins
 
 - **`GodotAssetsPlugin`**: Asset loading
+
   - Load Godot resources through Bevy's AssetServer
   - Supports .tscn, .tres, textures, sounds, etc.
   - Development and export path handling
 
 - **`GodotTransformSyncPlugin`**: Transform synchronization
+
   - Configure sync mode: `Disabled`, `OneWay` (default), or `TwoWay`
   - Synchronizes Bevy Transform components with Godot node transforms
   - Required for moving/positioning nodes from Bevy
 
 - **`GodotCollisionsPlugin`**: Collision detection
+
   - Monitors Area2D/3D and RigidBody2D/3D collision signals
   - Provides `Collisions` component with entered/exited tracking
   - Converts Godot collision signals to queryable data
 
 - **`GodotSignalsPlugin`**: Signal event bridge
+
   - Converts Godot signals to Bevy events
   - Use `EventReader<GodotSignal>` to handle signals
   - Essential for UI interactions (button clicks, etc.)
 
 - **`GodotInputEventPlugin`**: Raw input events
+
   - Provides Godot input as Bevy events
   - Keyboard, mouse, touch, gamepad, and action events
   - Lower-level alternative to `BevyInputBridgePlugin`
 
 - **`BevyInputBridgePlugin`**: Bevy input API
+
   - Use Bevy's standard `ButtonInput<KeyCode>`, mouse events, etc.
   - Automatically includes `GodotInputEventPlugin`
   - Higher-level, more ergonomic than raw events
 
 - **`GodotAudioPlugin`**: Audio system
+
   - Channel-based audio API
   - Spatial audio support
   - Audio tweening and easing
@@ -136,6 +155,7 @@ fn build_app(app: &mut App) {
 ### Game-Specific Configurations
 
 **Pure ECS Game**:
+
 ```rust
 #[bevy_app]
 fn build_app(app: &mut App) {
@@ -147,6 +167,7 @@ fn build_app(app: &mut App) {
 ```
 
 **Physics Platformer**:
+
 ```rust
 #[bevy_app]
 fn build_app(app: &mut App) {
@@ -160,6 +181,7 @@ fn build_app(app: &mut App) {
 ```
 
 **UI-Heavy Game**:
+
 ```rust
 #[bevy_app]
 fn build_app(app: &mut App) {
@@ -218,20 +240,25 @@ Some plugins automatically include their dependencies:
 7. **Do I want to spawn scenes at runtime?** → Add `GodotPackedScenePlugin`
 
 ### When in Doubt:
+
 Start with `GodotDefaultPlugins` and optimize later by removing unused plugins.
 
 ## Benefits
 
 ### Smaller Binaries
+
 Only compile the features you actually use.
 
 ### Better Performance
+
 Skip unused systems and resources.
 
 ### Clear Dependencies
+
 Your plugin list shows exactly what features you're using.
 
 ### Future-Proof
+
 New optional features can be added without breaking existing code.
 
 ## Migration Note

--- a/examples/avian-physics-demo/rust/Cargo.toml
+++ b/examples/avian-physics-demo/rust/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "avian_physics_test"
 version = "0.1.0"
-edition = "2021"
-rust-version = "1.82"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
@@ -14,11 +13,10 @@ name = "avian_physics_test"
 [dependencies]
 avian3d = "0.3"
 bevy = { version = "0.16", default-features = false, features = [
-    "bevy_asset",
-    "bevy_state",
-    "bevy_log",
-    "bevy_gilrs",
-    "multi_threaded",
+  "bevy_asset",
+  "bevy_state",
+  "bevy_gilrs",
+  "multi_threaded",
 ] }
 bevy_asset_loader = "0.23.0"
 godot = "0.3"

--- a/examples/avian-physics-demo/rust/src/lib.rs
+++ b/examples/avian-physics-demo/rust/src/lib.rs
@@ -1,28 +1,33 @@
-use avian3d::{collision::CollisionDiagnostics, dynamics::solver::SolverDiagnostics, prelude::*};
+use avian3d::{
+    collision::CollisionDiagnostics,
+    dynamics::solver::SolverDiagnostics,
+    prelude::{
+        AngularVelocity, Collider, Gravity, PhysicsPlugins, RigidBody, SpatialQueryDiagnostics,
+    },
+};
 use bevy::app::Startup;
-use bevy::ecs::schedule::common_conditions::run_once;
 use bevy::ecs::schedule::IntoScheduleConfigs;
+use bevy::ecs::schedule::common_conditions::run_once;
 use bevy::ecs::system::ResMut;
 use bevy::prelude::{
-    debug, Added, App, AppExtStates, Assets, Commands, Component, Entity, Event, EventReader,
-    EventWriter, Handle, Mesh, OnExit, Plugin, Query, Res, Resource, Result, States, Transform,
-    Vec3,
+    Added, App, AppExtStates, Assets, Commands, Component, Entity, Event, EventReader, EventWriter,
+    Handle, Mesh, OnExit, Plugin, Query, Res, Resource, Result, States, Transform, Vec3, debug,
 };
 use bevy::{scene::ScenePlugin, state::app::StatesPlugin};
 use bevy_asset_loader::{
     asset_collection::AssetCollection,
-    loading_state::{config::ConfigureLoadingState, LoadingState, LoadingStateAppExt},
+    loading_state::{LoadingState, LoadingStateAppExt, config::ConfigureLoadingState},
 };
 use godot::classes::{BoxMesh, MeshInstance3D};
+use godot_bevy::plugins::GodotBevyLogPlugin;
 use godot_bevy::plugins::scene_tree::SceneTreeConfig;
 use godot_bevy::prelude::{
-    bevy_app,
-    godot_prelude::{gdextension, ExtensionLibrary},
-    GodotNodeHandle, GodotResource, GodotScene,
+    GodotAssetsPlugin, GodotPackedScenePlugin, GodotTransformSyncPlugin, PhysicsUpdate,
+    main_thread_system,
 };
 use godot_bevy::prelude::{
-    main_thread_system, GodotAssetsPlugin, GodotPackedScenePlugin, GodotTransformSyncPlugin,
-    PhysicsUpdate,
+    GodotNodeHandle, GodotResource, GodotScene, bevy_app,
+    godot_prelude::{ExtensionLibrary, gdextension},
 };
 use std::fmt::Debug;
 
@@ -45,6 +50,7 @@ impl Plugin for AvianPhysicsDemo {
         app.add_plugins(StatesPlugin)
             .add_plugins(GodotAssetsPlugin)
             .add_plugins(GodotPackedScenePlugin)
+            .add_plugins(GodotBevyLogPlugin::default())
             .add_plugins(GodotTransformSyncPlugin::default())
             .add_plugins((
                 // Plugins required by Avian

--- a/examples/run_godot.rs
+++ b/examples/run_godot.rs
@@ -1,7 +1,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
-    process::{exit, Command, Stdio},
+    process::{Command, Stdio, exit},
 };
 
 use which::{which, which_in_global};

--- a/godot-bevy/Cargo.toml
+++ b/godot-bevy/Cargo.toml
@@ -11,9 +11,9 @@ license.workspace = true
 
 [dependencies]
 bevy = { version = "0.16", default-features = false, features = [
-    "bevy_asset",
-    "bevy_log",
-    "multi_threaded",
+  "bevy_asset",
+  "bevy_log",
+  "multi_threaded",
 ] }
 godot = { version = "0.3.0", features = ["experimental-threads"] }
 godot-bevy-macros.workspace = true
@@ -24,6 +24,7 @@ once_cell = "1.21"
 parking_lot = "0.12.4"
 inventory = "0.3"
 paste = "1.0"
+chrono = "0.4"
 
 [features]
 default = ["bevy_gamepad"]

--- a/godot-bevy/Cargo.toml
+++ b/godot-bevy/Cargo.toml
@@ -12,7 +12,6 @@ license.workspace = true
 [dependencies]
 bevy = { version = "0.16", default-features = false, features = [
   "bevy_asset",
-  "bevy_log",
   "multi_threaded",
 ] }
 godot = { version = "0.3.0", features = ["experimental-threads"] }
@@ -24,9 +23,11 @@ once_cell = "1.21"
 parking_lot = "0.12.4"
 inventory = "0.3"
 paste = "1.0"
+#[cfg(feature = "godot_bevy_log")]
 chrono = "0.4"
 
 [features]
-default = ["bevy_gamepad"]
+default = ["bevy_gamepad", "godot_bevy_log"]
 # Enable Bevy's gamepad support via gilrs
 bevy_gamepad = ["bevy/bevy_gilrs"]
+godot_bevy_log = []

--- a/godot-bevy/src/plugins/core.rs
+++ b/godot-bevy/src/plugins/core.rs
@@ -163,7 +163,6 @@ pub struct GodotBaseCorePlugin;
 impl Plugin for GodotBaseCorePlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(MinimalPlugins.build().disable::<ScheduleRunnerPlugin>())
-            .add_plugins(bevy::log::LogPlugin::default())
             .add_plugins(bevy::diagnostic::DiagnosticsPlugin)
             .init_resource::<PhysicsDelta>()
             .init_non_send_resource::<MainThreadMarker>()

--- a/godot-bevy/src/plugins/godot_bevy_logger.rs
+++ b/godot-bevy/src/plugins/godot_bevy_logger.rs
@@ -1,0 +1,157 @@
+use bevy::{
+    app::{App, Plugin},
+    log::{
+        Level, tracing,
+        tracing_subscriber::{self, EnvFilter},
+    },
+};
+use chrono::Local;
+use godot::global::{godot_error, godot_print, godot_print_rich, godot_warn};
+use std::path::{MAIN_SEPARATOR_STR, Path};
+use tracing_subscriber::{
+    Layer, field::Visit, filter::LevelFilter, layer::SubscriberExt, util::SubscriberInitExt,
+};
+
+pub struct GodotBevyLogPlugin {
+    /// Logs messages of this level or higher severity. Defaults to `LevelFilter::INFO`
+    level_filter: LevelFilter,
+
+    /// Enable/disable color in output. NOTE: Enabling this incurs
+    /// a performance penality. Defaults to true.
+    color: bool,
+
+    /// Accepts timestamp formatting, see <https://docs.rs/chrono/0.4.41/chrono/format/strftime/index.html>
+    /// You can disable the timestamp entirely by providing `None`.
+    /// Example default format: `11:30:37.631`
+    timestamp_format: Option<String>,
+}
+
+impl Default for GodotBevyLogPlugin {
+    fn default() -> Self {
+        Self {
+            level_filter: LevelFilter::INFO,
+
+            color: true,
+
+            // Timestamp formatting reference https://docs.rs/chrono/0.4.41/chrono/format/strftime/index.html
+            timestamp_format: Some("%T%.3f".to_owned()),
+        }
+    }
+}
+
+impl Plugin for GodotBevyLogPlugin {
+    fn build(&self, _app: &mut App) {
+        let env_filter = EnvFilter::builder()
+            .with_default_directive(self.level_filter.into())
+            // Add override support via RUST_LOG env variable, e.g., `RUST_LOG=WARN cargo run` will filter-in warning and higher messages only
+            .from_env_lossy();
+
+        tracing_subscriber::registry()
+            .with(GodotProxyLayer {
+                color: self.color,
+                timestamp_format: self.timestamp_format.clone(),
+            })
+            .with(env_filter)
+            .init();
+    }
+}
+
+struct GodotProxyLayerVistitor(Option<String>);
+
+impl Visit for GodotProxyLayerVistitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.0 = Some(format!("{value:?}"))
+        }
+    }
+}
+
+struct GodotProxyLayer {
+    color: bool,
+    timestamp_format: Option<String>,
+}
+
+impl<S> Layer<S> for GodotProxyLayer
+where
+    S: tracing::Subscriber,
+{
+    // When choosing colors in here, I tried to pick colors that were (a) gentler on the eyes when
+    // using the default godot theme, and (b) which provided the highest contrast for user
+    // generated content (actual message, level) and lower contrast for content that is generated
+    // (timestamp, location). The ultimate goal was to optimize for fast readability against
+    // dark themes (godot default and typical terminals)
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _context: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let metadata = event.metadata();
+        let mut msg_vistor = GodotProxyLayerVistitor(None);
+        event.record(&mut msg_vistor);
+
+        // Timestamp formatting reference https://docs.rs/chrono/0.4.41/chrono/format/strftime/index.html
+        let timestamp = if let Some(format) = &self.timestamp_format {
+            format!("{} ", Local::now().format(format))
+        } else {
+            "".to_string()
+        };
+
+        let level = match self.color {
+            true => match *metadata.level() {
+                Level::TRACE => "[color=LightGreen]T[/color]",
+                Level::DEBUG => "[color=LightGreen]D[/color]",
+                Level::INFO => "[color=LightGreen]I[/color]",
+                Level::WARN => "[color=Yellow]W[/color]",
+                Level::ERROR => "[color=Salmon]E[/color]",
+            },
+
+            false => match *metadata.level() {
+                Level::TRACE => "T",
+                Level::DEBUG => "D",
+                Level::INFO => "I",
+                Level::WARN => "W",
+                Level::ERROR => "E",
+            },
+        };
+
+        let msg = msg_vistor.0.unwrap_or_default();
+
+        let short_location = if let Some(file) = metadata.file() {
+            let path = Path::new(file);
+
+            let mut x = path.iter().rev().take(2);
+            let file = x.next().unwrap_or_default().to_string_lossy();
+            let parent = if let Some(parent) = x.next() {
+                format!("{}{}", parent.to_string_lossy(), MAIN_SEPARATOR_STR)
+            } else {
+                String::default()
+            };
+
+            format!("{}{}:{}", parent, file, metadata.line().unwrap_or_default())
+        } else {
+            String::default()
+        };
+
+        match self.color {
+            true => godot_print_rich!(
+                "[color=DimGray]{}[/color]{} {} [color=DimGray]@ {}[/color]",
+                timestamp,
+                level,
+                msg,
+                short_location
+            ),
+
+            false => godot_print!("{}{} {} @ {}", timestamp, level, msg, short_location),
+        };
+
+        match *metadata.level() {
+            Level::WARN => {
+                godot_warn!("{}", msg);
+            }
+            Level::ERROR => {
+                godot_error!("{}", msg);
+            }
+            _ => {}
+        };
+    }
+}

--- a/godot-bevy/src/plugins/godot_bevy_logger.rs
+++ b/godot-bevy/src/plugins/godot_bevy_logger.rs
@@ -17,7 +17,7 @@ pub struct GodotBevyLogPlugin {
     level_filter: LevelFilter,
 
     /// Enable/disable color in output. NOTE: Enabling this incurs
-    /// a performance penality. Defaults to true.
+    /// a performance penalty. Defaults to true.
     color: bool,
 
     /// Accepts timestamp formatting, see <https://docs.rs/chrono/0.4.41/chrono/format/strftime/index.html>
@@ -56,9 +56,9 @@ impl Plugin for GodotBevyLogPlugin {
     }
 }
 
-struct GodotProxyLayerVistitor(Option<String>);
+struct GodotProxyLayerVisitor(Option<String>);
 
-impl Visit for GodotProxyLayerVistitor {
+impl Visit for GodotProxyLayerVisitor {
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
         if field.name() == "message" {
             self.0 = Some(format!("{value:?}"))
@@ -86,7 +86,7 @@ where
         _context: tracing_subscriber::layer::Context<'_, S>,
     ) {
         let metadata = event.metadata();
-        let mut msg_vistor = GodotProxyLayerVistitor(None);
+        let mut msg_vistor = GodotProxyLayerVisitor(None);
         event.record(&mut msg_vistor);
 
         // Timestamp formatting reference https://docs.rs/chrono/0.4.41/chrono/format/strftime/index.html
@@ -124,12 +124,12 @@ where
             let parent = if let Some(parent) = x.next() {
                 format!("{}{}", parent.to_string_lossy(), MAIN_SEPARATOR_STR)
             } else {
-                String::default()
+                String::new()
             };
 
             format!("{}{}:{}", parent, file, metadata.line().unwrap_or_default())
         } else {
-            String::default()
+            String::new()
         };
 
         match self.color {

--- a/godot-bevy/src/plugins/mod.rs
+++ b/godot-bevy/src/plugins/mod.rs
@@ -6,6 +6,7 @@ pub mod assets;
 pub mod audio;
 pub mod collisions;
 pub mod core;
+pub mod godot_bevy_logger;
 pub mod input;
 pub mod packed_scene;
 pub mod scene_tree;
@@ -17,6 +18,7 @@ pub use assets::GodotAssetsPlugin;
 pub use audio::GodotAudioPlugin;
 pub use collisions::GodotCollisionsPlugin;
 pub use core::GodotBaseCorePlugin;
+pub use godot_bevy_logger::GodotBevyLogPlugin;
 pub use input::{BevyInputBridgePlugin, GodotInputEventPlugin};
 pub use packed_scene::GodotPackedScenePlugin;
 pub use scene_tree::GodotSceneTreePlugin;
@@ -33,6 +35,7 @@ plugin_group! {
     pub struct GodotCorePlugins {
         :GodotBaseCorePlugin,
         :GodotSceneTreePlugin,
+        :GodotBevyLogPlugin,
     }
 }
 

--- a/godot-bevy/src/plugins/mod.rs
+++ b/godot-bevy/src/plugins/mod.rs
@@ -31,7 +31,7 @@ pub use input::GodotInputEventPlugin as GodotInputPlugin;
 
 plugin_group! {
     /// Minimal core functionality required for Godot-Bevy integration.
-    /// This includes scene tree management, asset loading, logging, and basic bridge components.
+    /// This includes scene tree management
     pub struct GodotCorePlugins {
         :GodotBaseCorePlugin,
         :GodotSceneTreePlugin,

--- a/godot-bevy/src/plugins/mod.rs
+++ b/godot-bevy/src/plugins/mod.rs
@@ -31,11 +31,10 @@ pub use input::GodotInputEventPlugin as GodotInputPlugin;
 
 plugin_group! {
     /// Minimal core functionality required for Godot-Bevy integration.
-    /// This includes scene tree management and basic bridge components.
+    /// This includes scene tree management, asset loading, logging, and basic bridge components.
     pub struct GodotCorePlugins {
         :GodotBaseCorePlugin,
         :GodotSceneTreePlugin,
-        :GodotBevyLogPlugin,
     }
 }
 
@@ -49,6 +48,7 @@ plugin_group! {
         :GodotAudioPlugin,
         :GodotPackedScenePlugin,
         :GodotTransformSyncPlugin,
+        :GodotBevyLogPlugin,
         #[cfg(feature = "bevy_gamepad")]
         :GilrsPlugin,
     }

--- a/godot-bevy/src/plugins/mod.rs
+++ b/godot-bevy/src/plugins/mod.rs
@@ -48,6 +48,7 @@ plugin_group! {
         :GodotAudioPlugin,
         :GodotPackedScenePlugin,
         :GodotTransformSyncPlugin,
+        #[cfg(feature = "godot_bevy_log")]
         :GodotBevyLogPlugin,
         #[cfg(feature = "bevy_gamepad")]
         :GilrsPlugin,


### PR DESCRIPTION
* `GodotBevyLogPlugin`: Improved logging by default
  * Log message components are color-coded for readability by default. Color coding can be disabled entirely. NOTE: There is a performance penality for color-coding, so if your application is very performance sensitive, consider disabling this feature
  * Log messages are prefixed with a short timestamp, e.g., `12:00:36.196`. Timestamps can be customized or entirely disabled
  * Log messages are prefixed with a short log level, e.g., `T` for `TRACE`, `D` for `DEBUG`, `I` for `INFO`, `W` for `WARN`, `E` for `ERROR`
  * Log messages are suffixed with a shortened path and line number location, e.g., `@ loading_state/systems.rs:186`
  * Log level filtering is `INFO` and higher severity by default, this can be customized directly in your code or set at runtime using `RUST_LOG`, e.g., `RUST_LOG=trace cargo run`

Given this code:

```rust
        godot::global::godot_print!("this is a regular godot_print! message");
        bevy::log::trace!("this is an trace! message");
        bevy::log::debug!("this is an debug! message");
        bevy::log::info!("this is an info! message");
        bevy::log::warn!("this is an warn! message");
        bevy::log::error!("this is an error! message");
```

Here is what the output looks like:

Terminal
<img width="1712" height="522" alt="Screenshot from 2025-07-22 12-45-19" src="https://github.com/user-attachments/assets/13f47c40-8b3b-4436-9957-f6bc035041e6" />

Godot Output Panel
<img width="1156" height="264" alt="Screenshot from 2025-07-22 12-45-40" src="https://github.com/user-attachments/assets/5374fffb-4e51-4501-8f5d-636f2b2a0c08" />

Godot Debugger Panel
<img width="1151" height="302" alt="Screenshot from 2025-07-22 12-47-54" src="https://github.com/user-attachments/assets/a066efe1-3b89-4c3e-9bd4-08c9662f93ed" />

