### PR TITLE
Devenv bump, rust edition cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3742,7 +3742,7 @@ dependencies = [
  "fastrand",
  "godot",
  "godot-bevy",
- "which 7.0.3",
+ "which 8.0.0",
 ]
 
 [[package]]
@@ -3754,7 +3754,7 @@ dependencies = [
  "fastrand",
  "godot",
  "godot-bevy",
- "which 7.0.3",
+ "which 8.0.0",
 ]
 
 [[package]]
@@ -3800,7 +3800,7 @@ dependencies = [
  "godot",
  "godot-bevy",
  "leafwing-input-manager",
- "which 7.0.3",
+ "which 8.0.0",
 ]
 
 [[package]]

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -39,7 +39,7 @@ Edit `rust/Cargo.toml`:
 [package]
 name = "your_game_name"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
@@ -126,16 +126,19 @@ cargo build
 ### Common Issues
 
 **"Can't open dynamic library"**
+
 - Ensure the paths in `rust.gdextension` match your library output
 - Check that you've built the Rust project
 - On macOS, you may need to allow the library in System Preferences
 
 **"BevyApp not found"**
+
 - Make sure godot-bevy is properly added to your dependencies
 - Rebuild the Rust project
 - Restart the Godot editor
 
 **Build errors**
+
 - Verify your Rust version: `rustc --version`
 - Ensure all dependencies are compatible
 - Check for typos in the crate name

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1752692978,
+        "lastModified": 1753300020,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "b2281100077d641cbf135e8680e973c0c2270bc4",
+        "rev": "90266818017f7a6885edc75eb4a13b68862675ea",
         "type": "github"
       },
       "original": {
@@ -74,10 +74,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752596105,
+        "lastModified": 1753151930,
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dab3a6e781554f965bde3def0aa2fda4eb8f1708",
+        "rev": "83e677f31c84212343f4cc553bab85c2efcad60a",
         "type": "github"
       },
       "original": {
@@ -105,10 +105,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1752633862,
+        "lastModified": 1753325142,
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8668ca94858206ac3db0860a9dec471de0d995f8",
+        "rev": "cf608fb54d8854f31d7f7c499e2d2c928af48036",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -74,18 +74,4 @@ in
 
   # speed up rust builds through caching
   env.RUSTC_WRAPPER = "${pkgs.sccache}/bin/sccache";
-
-  # https://devenv.sh/git-hooks/
-  git-hooks.hooks = {
-    # lint shell scripts
-    shellcheck.enable = true;
-
-    rustfmt.enable = true;
-
-    # some hooks have more than one package, like clippy:
-    clippy.enable = true;
-    clippy.packageOverrides.cargo = pkgs.cargo;
-    clippy.packageOverrides.clippy = pkgs.clippy;
-    clippy.settings.allFeatures = true;
-  };
 }

--- a/examples/dodge-the-creeps-2d/rust/Cargo.toml
+++ b/examples/dodge-the-creeps-2d/rust/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "rust"
 version = "0.1.0"
-edition = "2021"
-rust-version = "1.82"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
@@ -17,4 +16,4 @@ bevy_asset_loader = "0.23.0"
 fastrand = { version = "2.3.0" }
 godot = "0.3"
 godot-bevy = { path = "../../../godot-bevy" }
-which = "7.0.3"
+which = "8"

--- a/examples/dodge-the-creeps-2d/rust/src/gameplay/audio.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/gameplay/audio.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use bevy::state::state::{OnEnter, OnExit};
 use bevy_asset_loader::asset_collection::AssetCollection;
 use godot_bevy::prelude::{
-    main_thread_system, AudioApp, AudioChannel, AudioChannelMarker, GodotResource,
+    AudioApp, AudioChannel, AudioChannelMarker, GodotResource, main_thread_system,
 };
 
 use crate::GameState;

--- a/examples/dodge-the-creeps-2d/rust/src/gameplay/countdown.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/gameplay/countdown.rs
@@ -16,8 +16,8 @@ use bevy::{
 use godot_bevy::prelude::Groups;
 
 use crate::{
-    commands::{NodeCommand, UICommand},
     GameState,
+    commands::{NodeCommand, UICommand},
 };
 
 pub struct CountdownPlugin;

--- a/examples/dodge-the-creeps-2d/rust/src/gameplay/gameover.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/gameplay/gameover.rs
@@ -13,7 +13,7 @@ use bevy::{
     time::{Time, Timer, TimerMode},
 };
 
-use crate::{commands::UICommand, GameState};
+use crate::{GameState, commands::UICommand};
 
 pub struct GameoverPlugin;
 impl Plugin for GameoverPlugin {

--- a/examples/dodge-the-creeps-2d/rust/src/gameplay/mob.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/gameplay/mob.rs
@@ -1,9 +1,9 @@
 use crate::gameplay::audio::GameSfxChannel;
 use crate::{
-    commands::{AnimationState, NodeCommand},
     GameState,
+    commands::{AnimationState, NodeCommand},
 };
-use bevy::math::{vec3, Vec3Swizzles};
+use bevy::math::{Vec3Swizzles, vec3};
 use bevy::transform::components::Transform;
 use bevy::{
     app::{App, Plugin, Update},
@@ -29,8 +29,8 @@ use godot::{
 use godot_bevy::{
     interop::GodotNodeHandle,
     prelude::{
-        main_thread_system, AudioChannel, FindEntityByNameExt, GodotResource, GodotScene,
-        GodotSignal, GodotSignals, NodeTreeView,
+        AudioChannel, FindEntityByNameExt, GodotResource, GodotScene, GodotSignal, GodotSignals,
+        NodeTreeView, main_thread_system,
     },
 };
 use std::f32::consts::PI;

--- a/examples/dodge-the-creeps-2d/rust/src/gameplay/player.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/gameplay/player.rs
@@ -1,12 +1,12 @@
 use crate::{
+    GameState,
     commands::{AnimationState, CachedScreenSize, VisibilityState},
     nodes::player::Player as GodotPlayerNode,
-    GameState,
 };
 use bevy::prelude::{
-    in_state, App, Commands, Component, Entity, Handle, IntoScheduleConfigs, Name, NextState,
-    OnEnter, OnExit, Plugin, Query, Res, ResMut, Resource, Result, Transform, Update, With,
-    Without,
+    App, Commands, Component, Entity, Handle, IntoScheduleConfigs, Name, NextState, OnEnter,
+    OnExit, Plugin, Query, Res, ResMut, Resource, Result, Transform, Update, With, Without,
+    in_state,
 };
 use bevy_asset_loader::asset_collection::AssetCollection;
 use godot::{

--- a/examples/dodge-the-creeps-2d/rust/src/gameplay/score.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/gameplay/score.rs
@@ -12,8 +12,8 @@ use bevy::{
 };
 
 use crate::{
-    commands::{UICommand, UIElement},
     GameState, Score,
+    commands::{UICommand, UIElement},
 };
 
 pub struct ScorePlugin;

--- a/examples/dodge-the-creeps-2d/rust/src/lib.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/lib.rs
@@ -4,8 +4,9 @@ use bevy::{prelude::*, state::app::StatesPlugin};
 use bevy_asset_loader::prelude::*;
 use gameplay::{audio::GameAudio, mob::MobAssets, player::PlayerAssets};
 use godot_bevy::prelude::{
-    godot_prelude::{gdextension, ExtensionLibrary},
-    GodotDefaultPlugins, *,
+    GodotDefaultPlugins,
+    godot_prelude::{ExtensionLibrary, gdextension},
+    *,
 };
 
 mod commands;

--- a/examples/dodge-the-creeps-2d/rust/src/main_menu.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/main_menu.rs
@@ -13,12 +13,12 @@ use bevy::{
 };
 use godot_bevy::{
     interop::GodotNodeHandle,
-    prelude::{main_thread_system, GodotSignal, GodotSignals, NodeTreeView, SceneTreeRef},
+    prelude::{GodotSignal, GodotSignals, NodeTreeView, SceneTreeRef, main_thread_system},
 };
 
 use crate::{
-    commands::{UICommand, UIElement, UIHandles},
     GameState,
+    commands::{UICommand, UIElement, UIHandles},
 };
 
 #[derive(Resource, Default)]

--- a/examples/input-event-demo/rust/Cargo.toml
+++ b/examples/input-event-demo/rust/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "rustinput"
 version = "0.1.0"
-edition = "2021"
-rust-version = "1.82"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
@@ -17,4 +16,4 @@ fastrand = { version = "2.3.0" }
 godot = "0.3"
 godot-bevy = { path = "../../../godot-bevy" }
 leafwing-input-manager = "0.17.0"
-which = "7.0.3"
+which = "8"

--- a/examples/input-event-demo/rust/src/leafwing_input.rs
+++ b/examples/input-event-demo/rust/src/leafwing_input.rs
@@ -102,7 +102,9 @@ fn update_player_input(query: Query<&ActionState<PlayerAction>, With<Player>>) {
         }
 
         // Test specific input types
-        godot_print!("  - Testing keyboard (WASD/arrows), mouse (left click + movement), gamepad (left stick + A button)");
+        godot_print!(
+            "  - Testing keyboard (WASD/arrows), mouse (left click + movement), gamepad (left stick + A button)"
+        );
 
         let mouse_axis = action_state.axis_pair(&PlayerAction::MouseLook);
         if mouse_axis.xy().length() > 0.1 {

--- a/examples/input-event-demo/rust/src/lib.rs
+++ b/examples/input-event-demo/rust/src/lib.rs
@@ -2,8 +2,9 @@
 
 use bevy::prelude::*;
 use godot_bevy::prelude::{
-    godot_prelude::{gdextension, ExtensionLibrary},
-    BevyInputBridgePlugin, *,
+    BevyInputBridgePlugin,
+    godot_prelude::{ExtensionLibrary, gdextension},
+    *,
 };
 
 mod bevy_input;

--- a/examples/platformer-2d/rust/Cargo.toml
+++ b/examples/platformer-2d/rust/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "rust-platformer-2d"
 version = "0.1.0"
-edition = "2021"
-rust-version = "1.82"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
@@ -17,4 +16,4 @@ bevy_asset_loader = "0.23.0"
 fastrand = { version = "2.3.0" }
 godot = "0.3"
 godot-bevy = { path = "../../../godot-bevy" }
-which = "7.0.3"
+which = "8"

--- a/examples/platformer-2d/rust/src/gameplay/audio.rs
+++ b/examples/platformer-2d/rust/src/gameplay/audio.rs
@@ -7,14 +7,13 @@
 //! These sets can run in parallel since they use separate audio channels
 //! and have no shared mutable state, improving audio responsiveness.
 
+use crate::GameState;
+use crate::level_manager::{LevelId, LevelLoadedEvent};
 use bevy::prelude::*;
 use bevy::state::condition::in_state;
 use bevy::state::state::OnExit;
 use bevy_asset_loader::asset_collection::AssetCollection;
 use godot_bevy::prelude::{AudioApp, AudioChannel, AudioChannelMarker, GodotResource};
-
-use crate::level_manager::{LevelId, LevelLoadedEvent};
-use crate::GameState;
 
 /// System sets for audio operations that can run in parallel
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]

--- a/examples/platformer-2d/rust/src/gameplay/mod.rs
+++ b/examples/platformer-2d/rust/src/gameplay/mod.rs
@@ -1,21 +1,19 @@
+use crate::GameState;
+use crate::level_manager::{CurrentLevel, LevelLoadedEvent};
+use crate::scene_management::SceneOperationEvent;
 use bevy::app::{App, Plugin};
 use bevy::prelude::*;
 use bevy::state::condition::in_state;
 use bevy::state::state::NextState;
+use gem::GemsCollected;
 use godot::classes::Input;
-
-use crate::level_manager::{CurrentLevel, LevelLoadedEvent};
-use crate::scene_management::SceneOperationEvent;
-use crate::GameState;
+use hud::{HudHandles, HudUpdateEvent};
 
 pub mod audio;
 pub mod door;
 pub mod gem;
 pub mod hud;
 pub mod player;
-
-use gem::GemsCollected;
-use hud::{HudHandles, HudUpdateEvent};
 
 /// System sets for gameplay operations with better parallelization
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]

--- a/examples/platformer-2d/rust/src/level_manager.rs
+++ b/examples/platformer-2d/rust/src/level_manager.rs
@@ -133,8 +133,7 @@ fn handle_level_scene_change(
     mut scene_events: EventWriter<SceneOperationEvent>,
     mut assets: ResMut<Assets<GodotResource>>,
 ) {
-    if let (Some(level_id), Some(ref handle)) =
-        (current_level.level_id, &loading_state.loading_handle)
+    if let (Some(level_id), Some(handle)) = (current_level.level_id, &loading_state.loading_handle)
     {
         // Check if the asset is loaded
         if let Some(_godot_resource) = assets.get_mut(handle) {

--- a/examples/platformer-2d/rust/src/lib.rs
+++ b/examples/platformer-2d/rust/src/lib.rs
@@ -2,8 +2,9 @@ use bevy::{prelude::*, state::app::StatesPlugin};
 use bevy_asset_loader::prelude::*;
 use gameplay::audio::GameAudio;
 use godot_bevy::prelude::{
-    godot_prelude::{gdextension, ExtensionLibrary},
-    GodotDefaultPlugins, *,
+    GodotDefaultPlugins,
+    godot_prelude::{ExtensionLibrary, gdextension},
+    *,
 };
 
 mod components;

--- a/examples/platformer-2d/rust/src/main_menu.rs
+++ b/examples/platformer-2d/rust/src/main_menu.rs
@@ -1,3 +1,7 @@
+use crate::{
+    GameState,
+    level_manager::{LevelId, LoadLevelEvent},
+};
 use bevy::{
     app::prelude::*,
     ecs::{
@@ -12,13 +16,8 @@ use bevy::{
         state::{NextState, OnEnter},
     },
 };
-use godot::classes::{display_server::WindowMode, Button, DisplayServer, Node};
+use godot::classes::{Button, DisplayServer, Node, display_server::WindowMode};
 use godot_bevy::prelude::*;
-
-use crate::{
-    level_manager::{LevelId, LoadLevelEvent},
-    GameState,
-};
 
 #[derive(Resource, Default)]
 pub struct MenuAssets {


### PR DESCRIPTION
Not much interesting here, just cleanup/updates.

- `devenv update`, I'm not running the latest official release - `devenv 1.8.0`
- removed git hooks from devenv, found these were installed globally, so they were affecting all of my git repositories, that's definitely not what we want
- visited all workspace examples, updated rust edition (and code) to conform to 2024
- bump which dependencies to latest official release