### PR TITLE
Replace lazy_static with standard library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2155,7 +2155,6 @@ dependencies = [
  "godot",
  "godot-bevy-macros",
  "inventory",
- "lazy_static",
  "once_cell",
  "parking_lot",
  "paste",

--- a/godot-bevy-macros/src/lib.rs
+++ b/godot-bevy-macros/src/lib.rs
@@ -50,10 +50,9 @@ pub fn bevy_app(_attr: TokenStream, item: TokenStream) -> TokenStream {
             fn on_level_init(level: godot::prelude::InitLevel) {
                 if level == godot::prelude::InitLevel::Core {
                     godot::private::class_macros::registry::class::auto_register_classes(level);
-                    let mut app_builder_func = godot_bevy::app::BEVY_INIT_FUNC.lock().unwrap();
-                    if app_builder_func.is_none() {
-                        *app_builder_func = Some(Box::new(#name));
-                    }
+                    // Stores the client's entrypoint, which we'll call shortly when our `BevyApp`
+                    // Godot Node has its `ready()` invoked
+                    let _ = godot_bevy::app::BEVY_INIT_FUNC.get_or_init(|| Box::new(#name));
                 }
             }
         }

--- a/godot-bevy/Cargo.toml
+++ b/godot-bevy/Cargo.toml
@@ -17,7 +17,6 @@ bevy = { version = "0.16", default-features = false, features = [
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 godot = { version = "0.3.0", features = ["experimental-threads"] }
 godot-bevy-macros.workspace = true
-lazy_static = "1.5.0"
 thiserror = "2.0.12"
 futures-lite = "2.6"
 once_cell = "1.21"


### PR DESCRIPTION
## Description
One less dependency and I think the standard library version's code is a
bit more readable.

## Checklist

- [x] Create awesomeness!
- [na] Update book (if needed)
- [na] Add/update tests (if needed)
- [na] Update examples (if needed)
- [x] Run examples
- [x] Run `cargo fmt`

## Related Issues

Closes #[issue_number]
