### PR TITLE
Remove GodotSceneSpawned

### DIFF
--- a/godot-bevy/src/plugins/packed_scene.rs
+++ b/godot-bevy/src/plugins/packed_scene.rs
@@ -78,15 +78,12 @@ impl GodotScene {
     }
 }
 
-#[derive(Component, Debug, Default)]
-struct GodotSceneSpawned;
-
 #[main_thread_system]
 fn spawn_scene(
     mut commands: Commands,
     mut new_scenes: Query<
         (&mut GodotScene, Entity, Option<&Transform>),
-        Without<GodotSceneSpawned>,
+        Without<GodotNodeHandle>,
     >,
     mut scene_tree: SceneTreeRef,
     mut assets: ResMut<Assets<GodotResource>>,
@@ -143,7 +140,6 @@ fn spawn_scene(
 
         commands
             .entity(ent)
-            .insert(GodotNodeHandle::new(instance))
-            .insert(GodotSceneSpawned);
+            .insert(GodotNodeHandle::new(instance));
     }
 }


### PR DESCRIPTION

## Description

This changes the query looking for new scenes in `spawn_new_scenes` to those with `GodotScene` and `Without<GodotNodeHandle>`.

`GodotSceneSpawned` doesn't mark anything useful that `GodotNodeHandle`s presence or lack thereof doesn't already handle. The current setup also prevents use cases where you detach visual representation from an entity and want to reattach it later. Once you have inserted a `GodotScene` onto an entity, even if you later `remove` it, you cannot spawn another scene because your entity has `GodotSceneSpawned` still. And you can't `remove` `GodotSceneSpawned` because the `struct` is `private`. So you're left in a state where you can never attach a new scene on that entity again. This limits a number of potential applications and use cases, without actually adding value, as `GodotNodeHandle` already provides an indication of if the scene is present. 

## Checklist

- [ X ] Create awesomeness!
- [ X ] Update book (if needed)
- [ X ] Add/update tests (if needed) - no tests in the changed file
- [ X ] Update examples (if needed) - should not change any example behaviors
- [ ] Run examples
- [ ] Run `cargo fmt`

## Related Issues

Closes #[issue_number]
