### PR TITLE
Update book github link

### DIFF
--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -23,7 +23,7 @@ The easiest way to get started is using the godot-bevy editor plugin, which auto
 
 ### 1. Install the Plugin
 
-1. Download the `addons/godot-bevy` folder from the [godot-bevy repository](https://github.com/dtaralla/godot-bevy)
+1. Download the `addons/godot-bevy` folder from the [godot-bevy repository](https://github.com/bytemeadow/godot-bevy)
 2. Copy it to your Godot project's `addons/` directory
 3. In Godot, go to **Project > Project Settings > Plugins**
 4. Enable the "Godot-Bevy Integration" plugin


### PR DESCRIPTION
## Description

Updated the github link in the book as it was still pointing to `dtaralla` instead of `bytemeadow`

## Checklist

- [ ] Create awesomeness!
- [x] Update book (if needed)
- [ ] Add/update tests (if needed)
- [ ] Update examples (if needed)
- [ ] Run examples
- [ ] Run `cargo fmt`

## Related Issues

Closes no issues
