### PR TITLE
:fire: fix bevy init finalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,6 +2194,7 @@ name = "godot-bevy"
 version = "0.9.0"
 dependencies = [
  "bevy",
+ "bevy_tasks",
  "chrono",
  "futures-lite",
  "godot",

--- a/godot-bevy/Cargo.toml
+++ b/godot-bevy/Cargo.toml
@@ -31,6 +31,7 @@ tracing-tracy = { version = "0.11.4", default-features = false, features = [
   "enable",
 ], optional = true }
 tracing-subscriber = { version = "0.3.19", optional = true }
+bevy_tasks = "0.16.1"
 
 [features]
 default = ["bevy_gamepad", "godot_bevy_log"]

--- a/godot-bevy/src/app.rs
+++ b/godot-bevy/src/app.rs
@@ -112,6 +112,16 @@ impl INode for BevyApp {
         let app_builder_func = BEVY_INIT_FUNC.get().unwrap();
         app_builder_func(&mut app);
 
+        // Finalize plugins before any further operations
+        // This ensures all plugins are fully initialized
+        // before app.update() is called in process()
+        while app.plugins_state() == bevy::app::PluginsState::Adding {
+            #[cfg(not(all(target_arch = "wasm32", feature = "web")))]
+            bevy_tasks::tick_global_task_pools_on_main_thread();
+        }
+        app.finish();
+        app.cleanup();
+
         self.register_scene_tree_watcher(&mut app);
         self.register_optimized_scene_tree_watcher();
         self.register_signal_system(&mut app);


### PR DESCRIPTION
This does what the Minimal SchedulerPlugin would usually do initially. It's important because external plugins might rely on the `finish()` etc. steps like lightyear or replicon.

In 'normal' bevy apps you would call `app.run()` but as we want to use the godot lifecycle for updates, godot-bevy manually calls `app.update()`. `app.run()` would usually use a scheduler to run the update logic in a loop, but that's not all they do!

DefaultPlugins and MinimalPlugins register a scheduler and schedulers make sure that all systems are setup correctly when the app is started. These changes simply imitate what the [ScheduleRunnerPlugin](https://docs.rs/bevy/latest/bevy/app/struct.ScheduleRunnerPlugin.html)  would do.

## Description

<!-- Describe what you changed. -->
Added the following to `godot-bevy/src/app.rs`:

```rs
while app.plugins_state() == bevy::app::PluginsState::Adding {
    #[cfg(not(all(target_arch = "wasm32", feature = "web")))]
    bevy_tasks::tick_global_task_pools_on_main_thread();
}
app.finish();
app.cleanup();
```

<!-- Describe why you changed it. -->
It caused external crates like lightyear and replicon not to function as the plugins where not initialized properly.

## Checklist

- [x] Create awesomeness!
- n/a Update book (if needed)
- n/a Add/update tests (if needed)
- n/a Update examples (if needed)
- [ ] Run examples
- [ ] Run `cargo fmt`

## Related Issues

Closes #[issue_number]
