### PR TITLE
Added mouse wheel events

### DIFF
--- a/godot-bevy/src/plugins/input/mod.rs
+++ b/godot-bevy/src/plugins/input/mod.rs
@@ -8,7 +8,7 @@ pub use input_bridge::BevyInputBridgePlugin;
 // Re-export event types for convenience
 pub use events::{
     ActionInput, GamepadAxisInput, GamepadButtonInput, KeyboardInput, MouseButton,
-    MouseButtonInput, MouseMotion, TouchInput,
+    MouseButtonInput, MouseMotion, MouseWheel, TouchInput,
 };
 
 // Re-export input reader types

--- a/godot-bevy/src/prelude.rs
+++ b/godot-bevy/src/prelude.rs
@@ -22,7 +22,7 @@ pub use crate::plugins::{
     // Collisions
     input::{
         ActionInput, BevyInputBridgePlugin, GodotInputEventPlugin, KeyboardInput, MouseButtonInput,
-        MouseMotion,
+        MouseMotion, MouseWheel,
     },
     // Core functionality
     packed_scene::{GodotPackedScenePlugin, GodotScene},


### PR DESCRIPTION
## Description

Extended event bridge to include mouse wheel events.
Added this because `AccumulatedMouseScroll` didn't work for me, which is very strange,
since `AccumulatedMouseMotion` works as intended.

Something to consider - `MouseWheel` is not blocked by UI elements (like regular mouse clicks). I'm not sure if they should TBH. Personally I would prefer they are, and in case someone wants them regardless they should use be using `AccumulatedMouseScroll`. However, I'm not sure how to achieve that or if this is even possible. Perhaps this could be discussed/refined.

```
fn handle_mouse(
    accumulated_scroll: Res<AccumulatedMouseScroll>,
    accumulated_motion: Res<AccumulatedMouseMotion>,
) {
    //always prints Res(AccumulatedMouseScroll { unit: Line, delta: Vec2(0.0, 0.0) }) 
    //accumulated_motion is fine
    println!("{:?} {:?}", accumulated_scroll, accumulated_motion);
}
```

## Checklist

- [x] Create awesomeness!
- [x] Update book (if needed)
- [x] Add/update tests (if needed)
- [x] Update examples (if needed)
- [x] Run examples
- [x] Run `cargo fmt`

