### PR TITLE
Add `canceled` and `is_double_click` to MouseButtonInput

### DIFF
--- a/godot-bevy/src/plugins/input/events.rs
+++ b/godot-bevy/src/plugins/input/events.rs
@@ -61,6 +61,8 @@ pub struct MouseButtonInput {
     pub pressed: bool,
     pub position: Vec2,
     pub factor: f32,
+    pub canceled: bool,
+    pub is_double_click: bool,
 }
 
 /// Mouse motion event
@@ -239,6 +241,8 @@ fn extract_basic_input_events(
             pressed: mouse_button_event.is_pressed(),
             position: Vec2::new(position.x, position.y),
             factor: mouse_button_event.get_factor(),
+            canceled: mouse_button_event.is_canceled(),
+            is_double_click: mouse_button_event.is_double_click(),
         });
     }
     // Mouse motion


### PR DESCRIPTION
## Description

Extend `MouseButtonInput` event to include `canceled` and `is_double_click` properties from `InputEventMouseButton` for better parity.

## Checklist

- [x] Create awesomeness!
- [x] Update book (if needed)
- [x] Add/update tests (if needed)
- [x] Update examples (if needed)
- [x] Run examples
- [x] Run `cargo fmt`
