### PR TITLE
Handle punctuation when converting to snake case in addon script

### DIFF
--- a/addons/godot-bevy/plugin.gd
+++ b/addons/godot-bevy/plugin.gd
@@ -138,6 +138,7 @@ fn hello_world_system(mut timer: Local<f32>, time: Res<Time>) {
 	var gdextension_content = """[configuration]
 entry_symbol = "gdext_rust_init"
 compatibility_minimum = 4.1
+reloadable = true
 
 [libraries]
 linux.debug.x86_64 = "res://rust/target/debug/lib%s.so"

--- a/examples/dodge-the-creeps-2d/godot/rust.gdextension
+++ b/examples/dodge-the-creeps-2d/godot/rust.gdextension
@@ -1,6 +1,7 @@
 [configuration]
 entry_symbol = "gdext_rust_init"
 compatibility_minimum = 4.1
+reloadable = true
 
 [libraries]
 linux.debug.x86_64 = "res://../../../target/debug/librust.so"


### PR DESCRIPTION
## Description

Cargo converts hyphens to underscores when creating the output filenames from the package name. This change uses the to_snake_case builtin string function to account for non-alphanumeric characters and convert them to underscores and hopefully match the cargo output. I've tested this by copying the modified script into a new project and running the setup script, using a project name with a hyphen in it and confirming that the rust output name matches the names in rust.gdextension now.

## Checklist

- [ ] Create awesomeness!
- [ ] Update book (if needed)
- [ ] Add/update tests (if needed)
- [ ] Update examples (if needed)
- [ ] Run examples
- [ ] Run `cargo fmt`

## Related Issues

Closes #146
