### PR TITLE
Add cfg lint config to fix trace_tracy warning on build

### DIFF
--- a/addons/godot-bevy/plugin.gd
+++ b/addons/godot-bevy/plugin.gd
@@ -96,6 +96,10 @@ godot-bevy = { version = "%s", features = ["default"] }
 
 [workspace]
 # Empty workspace table to make this a standalone project
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(feature, values("trace_tracy"))']
 """ % [_to_snake_case(project_name), info.godot_bevy_version]
 
 	_save_file(rust_path.path_join("Cargo.toml"), cargo_content)

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -100,6 +100,10 @@ crate-type = ["cdylib"]
 godot-bevy = "0.9.1"
 bevy = { version = "0.16", default-features = false }
 godot = "0.3"
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(feature, values("trace_tracy"))']
 ```
 
 ## Configure Godot Integration

--- a/book/src/profiling/profiling.md
+++ b/book/src/profiling/profiling.md
@@ -51,8 +51,10 @@ If you see the following warning:
 warning: unexpected `cfg` condition value: `trace_tracy`
 ```
 
-after ugprading to Godot Bevy `0.9`, add the following at the top of the problematic file (wherever you use the `bevy_app` macro):
+after ugprading to Godot Bevy `0.9`, add the following to your Cargo.toml file
 
-```rust
-#![allow(unexpected_cfgs)] // silence potential `tracy_trace` feature config warning brought in by `bevy_app` macro
+```toml
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(feature, values("trace_tracy"))']
 ```


### PR DESCRIPTION
## Description

This switches the recommended approach to silence the warning about the unexpected cfg feature for `trace_tracy` to use the recommended linter config instead of silencing that linter completely in the lib.rs file. I also added it to the Cargo.toml that the editor plugin creates, so new users shouldn't have to worry about it at all.

I tried just adding this config to the package level Cargo.toml files, but I couldn't get that to actually silence the warning when pointing to my local version. If anyone knows how to do that I would be happy to switch to it though.

## Checklist

- [x] Create awesomeness!
- [x] Update book (if needed)
- [ ] Add/update tests (if needed)
- [ ] Update examples (if needed)
- [ ] Run examples
- [x] Run `cargo fmt`

## Related Issues

Closes #126 
