### PR TITLE
fix(transform sync macro): Add missing import for `Engine::singleton()`

### DIFF
--- a/godot-bevy/src/plugins/transforms/custom_sync.rs
+++ b/godot-bevy/src/plugins/transforms/custom_sync.rs
@@ -97,6 +97,7 @@ macro_rules! add_transform_sync_systems {
                 use godot::classes::{Engine, Node2D, Node3D, Object, SceneTree};
                 use godot::global::godot_print;
                 use godot::prelude::{Array, Dictionary, Gd, ToGodot};
+                use godot::obj::Singleton;
 
                 // Try to get the BevyAppSingleton autoload for bulk optimization
                 let engine = Engine::singleton();


### PR DESCRIPTION
## Description

Added a missing import for `Engine::singleton()`.
In godot-rust 0.4, singleton access has been moved to a dedicated Singleton trait which requires a new import.
See: https://godot-rust.github.io/book/migrate/v0.4.html
Missing this import breaks the `add_transform_sync_systems!` macro.

## Checklist

- [x] Create awesomeness!
- [ ] Update book (if needed)
- [ ] Add/update tests (if needed)
- [ ] Update examples (if needed)
- [ ] Run examples
- [x] Run `cargo fmt`
