### PR TITLE
fix(no static type in plugin): Add static type to rotation in GDScript

### DIFF
--- a/addons/godot-bevy/bevy_app_singleton.tscn
+++ b/addons/godot-bevy/bevy_app_singleton.tscn
@@ -13,7 +13,7 @@ func bulk_update_transforms_3d(
   rotations: PackedVector4Array,
   scales: PackedVector3Array
 ) -> void:
-	var rotation = Quaternion()
+	var rotation: Quaternion = Quaternion()
 	for i: int in range(instance_ids.size()):
 		var node: Node3D = instance_from_id(instance_ids[i]) as Node3D
 		# Trust instance IDs are valid


### PR DESCRIPTION
## Description

Added a static type to rotation in GDScript addon.
When godot is configured with strict warnings as errors, it will complain about addons.

## Checklist

- [x] Create awesomeness!
- [ ] Update book (if needed)
- [ ] Add/update tests (if needed)
- [ ] Update examples (if needed)
- [ ] Run examples
- [x] Run `cargo fmt`
