### PR TITLE
Improve signal

### DIFF
--- a/book/src/input/signals.md
+++ b/book/src/input/signals.md
@@ -32,7 +32,7 @@ fn connect_button(
     typed: TypedGodotSignals<StartGameRequested>,
 ) {
     for mut handle in &mut buttons {
-        typed.connect_map(&mut handle, "pressed", None, |_args, _node, _ent| StartGameRequested);
+        typed.connect_map(&mut handle, "pressed", None, |_args, _node, _ent| Some(StartGameRequested));
     }
 }
 ```
@@ -68,10 +68,10 @@ fn connect_menu(
     for (mut button, tag) in &mut menu {
         match tag {
             MenuTag::Fullscreen => {
-                toggle.connect_map(&mut button, "pressed", None, |_a, _n, _e| ToggleFullscreen);
+                toggle.connect_map(&mut button, "pressed", None, |_a, _n, _e| Some(ToggleFullscreen));
             }
             MenuTag::Quit => {
-                quit.connect_map(&mut button, "pressed", None, |_a, n, _e| QuitRequested { source: n.clone() });
+                quit.connect_map(&mut button, "pressed", None, |_a, n, _e| Some(QuitRequested { source: n.clone() }));
             }
         }
     }
@@ -97,7 +97,7 @@ fn connect_area(
     typed: TypedGodotSignals<AreaExited>,
 ) {
     for (entity, mut area) in &mut q {
-        typed.connect_map(&mut area, "body_exited", Some(entity), |_a, _n, e| AreaExited(e.unwrap()));
+        typed.connect_map(&mut area, "body_exited", Some(entity), |_a, _n, e| Some(AreaExited(e.unwrap())));
     }
 }
 ```
@@ -118,7 +118,7 @@ fn spawn_area(mut commands: Commands) {
     commands.spawn((
         MyArea,
         // Defer until GodotNodeHandle is available on this entity
-        TypedDeferredSignalConnections::<BodyEntered>::with_connection("body_entered", |_a, _n, e| BodyEntered(e.unwrap())),
+        TypedDeferredSignalConnections::<BodyEntered>::with_connection("body_entered", |_a, _n, e| Some(BodyEntered(e.unwrap()))),
     ));
 }
 ```

--- a/examples/dodge-the-creeps-2d/rust/src/gameplay/mob.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/gameplay/mob.rs
@@ -160,8 +160,10 @@ fn new_mob(
             &mut mob_nodes.visibility_notifier,
             "screen_exited",
             Some(entity),
-            |_args, _node, ent| MobScreenExited {
-                entity: ent.expect("entity was provided"),
+            |_args, _node, ent| {
+                Some(MobScreenExited {
+                    entity: ent.expect("entity was provided"),
+                })
             },
         );
 

--- a/examples/dodge-the-creeps-2d/rust/src/main_menu.rs
+++ b/examples/dodge-the-creeps-2d/rust/src/main_menu.rs
@@ -93,7 +93,7 @@ fn connect_start_button(
         menu_assets.start_button.as_mut().unwrap(),
         "pressed",
         None,
-        |_args, _node, _ent| StartGameRequested,
+        |_args, _node, _ent| Some(StartGameRequested),
     );
 }
 

--- a/examples/platformer-2d/rust/src/main_menu.rs
+++ b/examples/platformer-2d/rust/src/main_menu.rs
@@ -133,19 +133,19 @@ fn connect_buttons(
         // Get mutable references one at a time to avoid multiple borrows
         if let Some(start_btn) = menu_assets.start_button.as_mut() {
             typed_start.connect_map(start_btn, "pressed", None, |_args, _node, _ent| {
-                StartGameRequested
+                Some(StartGameRequested)
             });
         }
         if let Some(fullscreen_btn) = menu_assets.fullscreen_button.as_mut() {
             typed_fullscreen.connect_map(fullscreen_btn, "pressed", None, |_args, _node, _ent| {
-                ToggleFullscreenRequested
+                Some(ToggleFullscreenRequested)
             });
         }
         if let Some(quit_btn) = menu_assets.quit_button.as_mut() {
             typed_quit.connect_map(quit_btn, "pressed", None, |_args, node, _ent| {
-                QuitRequested {
+                Some(QuitRequested {
                     source: node.clone(),
-                }
+                })
             });
         }
 

--- a/godot-bevy/src/plugins/signals.rs
+++ b/godot-bevy/src/plugins/signals.rs
@@ -239,7 +239,7 @@ impl<'w, T: Event + Send + 'static> TypedGodotSignals<'w, T> {
         source_entity: Option<Entity>,
         mut mapper: F,
     ) where
-        F: FnMut(&[Variant], &GodotNodeHandle, Option<Entity>) -> T + Send + 'static,
+        F: FnMut(&[Variant], &GodotNodeHandle, Option<Entity>) -> Option<T> + Send + 'static,
     {
         let mut node_ref = node.get::<Node>();
         let signal_name_copy = signal_name.to_string();
@@ -250,7 +250,9 @@ impl<'w, T: Event + Send + 'static> TypedGodotSignals<'w, T> {
             // Clone variants to owned values we can inspect
             let owned: Vec<Variant> = args.iter().map(|&v| v.clone()).collect();
             let event = mapper(&owned, &source_node, source_entity);
-            let _ = sender_t.send(Box::new(TypedEnvelope::<T>(event)));
+            if let Some(event) = event {
+                let _ = sender_t.send(Box::new(TypedEnvelope::<T>(event)));
+            }
             Variant::nil()
         };
 
@@ -295,8 +297,9 @@ fn process_typed_deferred_signal_connections<T: Event + Send + 'static>(
 /// A single typed deferred connection item for `T` events
 pub struct TypedDeferredConnection<T: Event + Send + 'static> {
     pub signal_name: String,
-    pub mapper:
-        Box<dyn Fn(&[Variant], &GodotNodeHandle, Option<Entity>) -> T + Send + Sync + 'static>,
+    pub mapper: Box<
+        dyn Fn(&[Variant], &GodotNodeHandle, Option<Entity>) -> Option<T> + Send + Sync + 'static,
+    >,
 }
 
 /// Component to defer Godot signal connections until a `GodotNodeHandle` exists on the entity
@@ -320,7 +323,7 @@ impl<T: Event + Send + 'static> TypedDeferredSignalConnections<T> {
 
     pub fn with_connection<F>(signal_name: impl Into<String>, mapper: F) -> Self
     where
-        F: Fn(&[Variant], &GodotNodeHandle, Option<Entity>) -> T + Send + Sync + 'static,
+        F: Fn(&[Variant], &GodotNodeHandle, Option<Entity>) -> Option<T> + Send + Sync + 'static,
     {
         Self {
             connections: vec![TypedDeferredConnection {
@@ -332,7 +335,7 @@ impl<T: Event + Send + 'static> TypedDeferredSignalConnections<T> {
 
     pub fn push<F>(&mut self, signal_name: impl Into<String>, mapper: F)
     where
-        F: Fn(&[Variant], &GodotNodeHandle, Option<Entity>) -> T + Send + Sync + 'static,
+        F: Fn(&[Variant], &GodotNodeHandle, Option<Entity>) -> Option<T> + Send + Sync + 'static,
     {
         self.connections.push(TypedDeferredConnection {
             signal_name: signal_name.into(),


### PR DESCRIPTION
## Description

Adjust the return type of callback in the connect_map function to Option

```rust
fn connect_button(
    mut buttons: Query<&mut GodotNodeHandle, With<Button>>, 
    typed: TypedGodotSignals<StartGameRequested>,
) {
    for mut handle in &mut buttons {
        typed.connect_map(&mut handle, "pressed", None, |_args, _node, _ent| Some(StartGameRequested));
    }
}
```

## Checklist

- [ ] Create awesomeness!
- [x] Update book (if needed)
- [ ] Add/update tests (if needed)
- [x] Update examples (if needed)
- [ ] Run examples
- [x] Run `cargo fmt` 
