### PR TITLE
Make README's "basic example" valid for 0.9.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ cargo build --release --manifest-path examples/{example}/rust/Cargo.toml
 - **`GodotCorePlugins`**: Minimal required functionality 
 - **`GodotDefaultPlugins`**: All functionality enabled (use for easy migration)
 - **Individual plugins**: 
-  - `GodotTransformsPlugin` (move/position nodes from Bevy)
+  - `GodotTransformSyncPlugin` (move/position nodes from Bevy)
   - `GodotAudioPlugin` (play sounds/music from Bevy) 
   - `GodotSignalsPlugin` (respond to Godot signals in Bevy)
   - `GodotCollisionsPlugin` (detect collisions in Bevy)
@@ -80,7 +80,7 @@ fn build_app(app: &mut App) {
 // Add specific features as needed
 #[bevy_app]
 fn build_app(app: &mut App) {
-    app.add_plugins(GodotTransformsPlugin)      // Transform sync
+    app.add_plugins(GodotTransformSyncPlugin::default()) // Transform sync
         .add_plugins(GodotAudioPlugin)          // Audio system
         .add_plugins(BevyInputBridgePlugin);    // Input (auto-includes GodotInputEventPlugin)
 }

--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ Basic example:
 
 ```rust
 use bevy::prelude::*;
+use godot::prelude::*;
 use godot_bevy::prelude::*;
 
 #[bevy_app]
 fn build_app(app: &mut App) {
     // Add the features you need (v0.8+ opt-in plugin system)
-    app.add_plugins(GodotTransformsPlugin)  // Transform sync
-        .add_plugins(GodotAudioPlugin);     // Audio system
+    app.add_plugins(GodotTransformSyncPlugin::default())  // Transform sync
+        .add_plugins(GodotAudioPlugin);                   // Audio system
 
     // Print to the Godot console
     godot_print!("Hello from Godot-Bevy!");
@@ -102,9 +103,9 @@ fn build_app(app: &mut App) {
 // Add specific features as needed
 #[bevy_app]
 fn build_app(app: &mut App) {
-    app.add_plugins(GodotTransformsPlugin)  // Transform sync
-        .add_plugins(GodotAudioPlugin)      // Audio system
-        .add_plugins(BevyInputBridgePlugin); // Input handling
+    app.add_plugins(GodotTransformSyncPlugin::default())  // Transform sync
+        .add_plugins(GodotAudioPlugin)                    // Audio system
+        .add_plugins(BevyInputBridgePlugin);              // Input handling
 }
 
 // Or everything at once (like v0.7.x)


### PR DESCRIPTION
## Description

The `Basic example` in the README doesn't compile, so this fixes it. You can drop this in a `lib.rs` and it will work again! I also went ahead and updated the remaining mentions of `GodotTransformsPlugin`.

It will still produce a warning that can be allowed with `#![allow(unexpected_cfgs)]`, but I didn't want to add too much bloat!

## Checklist

- [x] Create awesomeness!
- [ ] Update book (if needed)
- [ ] Add/update tests (if needed)
- [ ] Update examples (if needed)
- [ ] Run examples
- [ ] Run `cargo fmt`
