### PR TITLE
fix(add_transform_sync_systems): Missing re-exported bevy_math dependency

### DIFF
--- a/godot-bevy/src/lib.rs
+++ b/godot-bevy/src/lib.rs
@@ -32,6 +32,7 @@ pub use paste;
 // users who depend on individual sub-crates and users who depend on the main bevy crate
 pub use bevy_app;
 pub use bevy_ecs;
+pub use bevy_math;
 pub use bevy_transform;
 
 pub struct GodotPlugin;


### PR DESCRIPTION
## Description

<!-- Describe what you changed. -->
<!-- Describe why you changed it. -->
I couldn't use `add_transform_sync_systems` because of a missing bevy_math dependency on `$crate::bevy_math`.

## Checklist

- [x] Create awesomeness!
- [ ] Update book (if needed)
  - [ ] Update migration guide (if breaking change)
  - [ ] Run `mdbook test` (if book was updated)
- [ ] Add/update tests (if needed)
- [ ] Update examples (if needed)
- [ ] Run examples
- [ ] Run `cargo fmt`

