### PR TITLE
Duplicate Resource registration fix

### DIFF
--- a/godot-bevy-macros/src/lib.rs
+++ b/godot-bevy-macros/src/lib.rs
@@ -63,7 +63,6 @@ pub fn bevy_app(attr: TokenStream, item: TokenStream) -> TokenStream {
         unsafe impl ExtensionLibrary for BevyExtensionLibrary {
             fn on_level_init(level: godot::prelude::InitLevel) {
                 if level == godot::prelude::InitLevel::Core {
-                    godot::private::class_macros::registry::class::auto_register_classes(level);
 
                     // Store the scene tree configuration
                     let _ = godot_bevy::app::BEVY_APP_CONFIG.set(godot_bevy::app::BevyAppConfig {


### PR DESCRIPTION
## Description

<!-- Describe what you changed. -->
Removed `auto_register_classes` from `on_level_init` in `BevyExtensionLibrary`.
<!-- Describe why you changed it. -->
Calling this function resulted in custom Godot classes inheriting `Resource` or `RefCounted` being registered and then unregistered twice which caused error messages and Godot Editor crashes.

## Checklist

- [x] Create awesomeness!
- [ ] Update book (if needed)
  - [ ] Update migration guide (if breaking change)
  - [ ] Run `mdbook test` (if book was updated)
- [ ] Add/update tests (if needed)
- [ ] Update examples (if needed)
- [x] Run examples
- [x] Run `cargo fmt`

## Related Issues

Closes #190
