### PR TITLE
fix(book-ci): Fix reference to book deploy repository

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -77,7 +77,7 @@ jobs:
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: peaceiris/actions-gh-pages@v4
         with:
-          external_repository: DragonAxe/godot-bevy-book
+          external_repository: ${{ github.repository_owner }}/godot-bevy-book
           publish_branch: main
           personal_token: ${{ secrets.GODOT_BEVY_BOOK_PUSH_TOKEN }}
           publish_dir: ./output


### PR DESCRIPTION
Quick fix to #216. I forgot to swap out my fork's repository for the owner's repository from when I was testing on my fork.