### PR TITLE
chore(cargo): Bump Godot-Bevy to 0.11 and Bevy to 0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "godot-bevy"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "godot-bevy-macros"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "godot-bevy-test"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bevy",
  "chrono",
@@ -2610,7 +2610,7 @@ dependencies = [
 
 [[package]]
 name = "godot-bevy-test-macros"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 authors = ["David Chavez <david@dcvz.io>"]
 repository = "https://github.com/bytemeadow/godot-bevy"
@@ -27,8 +27,8 @@ resolver = "2"
 
 [workspace.dependencies]
 godot = { version = "0.4.5" }
-godot-bevy = { version = "0.10.0", path = "godot-bevy" }
-godot-bevy-macros = { version = "0.10.0", path = "godot-bevy-macros" }
-godot-bevy-test = { version = "0.10.0", path = "godot-bevy-test" }
-godot-bevy-test-macros = { version = "0.10.0", path = "godot-bevy-test-macros" }
+godot-bevy = { version = "0.11.0", path = "godot-bevy" }
+godot-bevy-macros = { version = "0.11.0", path = "godot-bevy-macros" }
+godot-bevy-test = { version = "0.11.0", path = "godot-bevy-test" }
+godot-bevy-test-macros = { version = "0.11.0", path = "godot-bevy-test-macros" }
 cargo-godot-lib = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-godot-bevy = "0.10.0"  # Latest with opt-in plugin system
-bevy = { version = "0.17", default-features = false }
+godot-bevy = "0.11.0"  # Latest with opt-in plugin system
+bevy = { version = "0.18", default-features = false }
 godot = "0.4"
 ```
 
@@ -132,6 +132,7 @@ This library was inspired by and originally built upon the work of [bevy_godot](
 
 | `godot-bevy` | Bevy | Godot-Rust | Godot |
 |--------------|------|------------|-------|
+| 0.11.x       | 0.18 | 0.4        | 4.6.x |
 | 0.10.x       | 0.17 | 0.4        | 4.5.x |
 | 0.9.2        | 0.16 | 0.4        | 4.5.x |
 | 0.9.x        | 0.16 | 0.3        | 4.4.x |

--- a/addons/godot-bevy/plugin.cfg
+++ b/addons/godot-bevy/plugin.cfg
@@ -3,5 +3,5 @@
 name="godot-bevy"
 description="Seamlessly integrate Bevy ECS with Godot 4. Provides project scaffolding, BevyApp singleton setup, and development tools."
 author="dcvz"
-version="0.10.0"
+version="0.11.0"
 script="plugin.gd"

--- a/addons/godot-bevy/wizard/project_wizard.gd
+++ b/addons/godot-bevy/wizard/project_wizard.gd
@@ -7,7 +7,7 @@ signal project_created(project_info: Dictionary)
 @onready var version_input: LineEdit = $VBox/Version/LineEdit
 @onready var release_build_check: CheckBox = $VBox/ReleaseBuild
 
-const DEFAULT_VERSION = "0.10.0"
+const DEFAULT_VERSION = "0.11.0"
 
 func _ready():
 	title = "Setup godot-bevy Project"

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -33,7 +33,7 @@ The easiest way to get started is using the godot-bevy editor plugin, which auto
 1. Go to **Project > Tools > Setup godot-bevy Project**
 2. Configure your project settings:
    - **Project name**: Used for the Rust crate name
-   - **godot-bevy version**: Library version (default: 0.10.0)
+   - **godot-bevy version**: Library version (default: 0.11.0)
    - **Release build**: Whether to build in release mode initially
 3. Click **"Create Project"**
 
@@ -97,8 +97,8 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-godot-bevy = "0.10.0"
-bevy = { version = "0.17", default-features = false }
+godot-bevy = "0.11.0"
+bevy = { version = "0.18", default-features = false }
 godot = "0.4"
 ```
 

--- a/book/src/testing/index.md
+++ b/book/src/testing/index.md
@@ -45,9 +45,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 godot = "0.4"
-godot-bevy = "0.9"
-godot-bevy-test = "0.9"
-bevy = { version = "0.17", default-features = false }
+godot-bevy = "0.11"
+godot-bevy-test = "0.11"
+bevy = { version = "0.18", default-features = false }
 
 # Import your game crate to test its systems
 my-game = { path = "../my-game" }

--- a/godot-bevy-test/README.md
+++ b/godot-bevy-test/README.md
@@ -31,9 +31,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 godot = "0.4"
-godot-bevy = "0.9"
-godot-bevy-test = "0.9"
-bevy = { version = "0.17", default-features = false }
+godot-bevy = "0.11"
+godot-bevy-test = "0.11"
+bevy = { version = "0.18", default-features = false }
 
 # Your game crate (for testing your components/systems)
 my-game = { path = "../my-game" }


### PR DESCRIPTION
## Description

<!-- Describe what you changed. -->
<!-- Describe why you changed it. -->

## Checklist

- [x] Create awesomeness!
- [ ] Update book (if needed)
  - [ ] Update migration guide (if breaking change)
  - [ ] Run `mdbook test` (if book was updated)
- [ ] Add/update tests (if needed)
- [ ] Update examples (if needed)
- [ ] Run examples
- [ ] Run `cargo fmt --all`
- [ ] Run `cargo clippy`
