### PR TITLE
fix: add rust-flag to disable the `emscripten_wasm_eh` when building web example

### DIFF
--- a/examples/simple-node2d-movement/build-web.sh
+++ b/examples/simple-node2d-movement/build-web.sh
@@ -121,7 +121,7 @@ WASM_DIR="$WORKSPACE_ROOT/target/wasm32-unknown-emscripten/$BUILD_MODE"
 
 # Build non-threaded version (default, broader compatibility)
 echo "=== Building NON-THREADED version ==="
-RUSTFLAGS="-C link-args=-sSIDE_MODULE=2 -C link-args=-O0 -Zlink-native-libraries=no -Cllvm-args=-enable-emscripten-cxx-exceptions=0" \
+RUSTFLAGS="-C link-args=-sSIDE_MODULE=2 -C link-args=-O0 -Zlink-native-libraries=no -Cllvm-args=-enable-emscripten-cxx-exceptions=0 -Zemscripten-wasm-eh=false" \
     $CARGO_CMD build --no-default-features --features web-nothreads -Zbuild-std --target wasm32-unknown-emscripten $RELEASE_FLAG
 
 if [[ -f "$WASM_DIR/simple_node2d_movement_example.wasm" ]]; then
@@ -142,7 +142,7 @@ if [[ "$THREADED" == true ]] || [[ "$SERVE" == false ]]; then
     THREADED_WASM_DIR="$THREADED_TARGET_DIR/wasm32-unknown-emscripten/$BUILD_MODE"
 
     CARGO_TARGET_DIR="$THREADED_TARGET_DIR" \
-    RUSTFLAGS="-C link-args=-pthread -C target-feature=+atomics -C link-args=-sSIDE_MODULE=2 -C link-args=-O0 -Zlink-native-libraries=no -Cllvm-args=-enable-emscripten-cxx-exceptions=0" \
+    RUSTFLAGS="-C link-args=-pthread -C target-feature=+atomics -C link-args=-sSIDE_MODULE=2 -C link-args=-O0 -Zlink-native-libraries=no -Cllvm-args=-enable-emscripten-cxx-exceptions=0 -Zemscripten-wasm-eh=false" \
         $CARGO_CMD build --no-default-features --features web -Zbuild-std --target wasm32-unknown-emscripten $RELEASE_FLAG
 
     # Copy to main target dir with .threads.wasm suffix


### PR DESCRIPTION
## Description
* Based on recent developments of Godot Rust, it seems web builds require an additional rust-flag of `-Zemscripten_wasm_eh=false`. Otherwise running the web example will break at runtime.
  * Here's a godot-rust book  PR that documents the necessity of the flag: https://github.com/godot-rust/book/pull/125

<!--
## Checklist

- [x] Create awesomeness!
- [ ] Update book (if needed)
  - [ ] Update migration guide (if breaking change)
  - [ ] Run `mdbook test` (if book was updated)
- [ ] Add/update tests (if needed)
- [ ] Update examples (if needed)
- [ ] Run examples
- [ ] Run `cargo fmt --all`
- [ ] Run `cargo clippy`
-->