### PR TITLE
fix(book): add the build command to the example page in the book

### DIFF
--- a/book/src/getting-started/examples.md
+++ b/book/src/getting-started/examples.md
@@ -3,6 +3,7 @@
 Many additional godot-bevy examples are available in the [examples](https://github.com/bytemeadow/godot-bevy/tree/main/examples) directory. Examples are set up as executable binaries. An example can then be executed using the following cargo command line in the root of the godot-bevy repository:
 
 ```
+cargo build -p platformer-2d-example
 cargo run --bin platformer_2d_example
 ```
 


### PR DESCRIPTION
## Description

Added the build command in the book, since I tripped on that myself until I read the section "[Manual Installation Issues](https://bytemeadow.github.io/godot-bevy-book/main/getting-started/installation.html#manual-installation-issues)" . Would make new comers easier to try the example out.
<!-- Describe what you changed. -->
<!-- Describe why you changed it. -->

## Checklist

- [x] Create awesomeness!
- [x] Update book (if needed)
  - [ ] Update migration guide (if breaking change)
  - [ ] Run `mdbook test` (if book was updated)
- [ ] Add/update tests (if needed)
- [ ] Update examples (if needed)
- [x] Run examples
- [x] Run `cargo fmt --all`
- [x] Run `cargo clippy`
