### PR TITLE
feat(BevyApp): Expose the Bevy App to Godot nodes for Godot to Bevy communication

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -18,6 +18,7 @@
     - [Property Mapping (BevyBundle)](./scene-tree/custom-nodes/property-mapping-with-bevy-bundle.md)
     - [Nodes from Components and Bundles](scene-tree/custom-nodes/nodes-from-components-and-bundles.md)
   - [Spawning Scenes](scene-tree/spawning-scenes.md)
+  - [Godot to Bevy Communication](scene-tree/godot-to-bevy-communication.md)
 
 ---
 

--- a/book/src/migration/v0.11-to-v0.12.md
+++ b/book/src/migration/v0.11-to-v0.12.md
@@ -1,0 +1,21 @@
+# (Work in progress) Migration Guide: v0.11 to v0.12
+This guide covers breaking changes and new behavior when upgrading from godot-bevy 0.11.x to 0.12.0.
+
+## Table of Contents
+
+Breaking changes:
+
+- 
+
+New features:
+
+- [Bevy App Access from Godot Nodes](#new-bevy-app-access-from-godot-nodes)
+
+
+## New: Bevy App Access from Godot Nodes
+
+See [Godot to bevy communication](../scene-tree/godot-to-bevy-communication.md)
+
+## Migration Checklist
+
+-

--- a/book/src/project-transition/transitional-mailbox-bridge.md
+++ b/book/src/project-transition/transitional-mailbox-bridge.md
@@ -1,4 +1,9 @@
-# Transitional Mailbox Bridge (Godot -> Bevy Messages)
+# (Deprecated) Transitional Mailbox Bridge (Godot -> Bevy Messages)
+
+The mailbox bridge plugin has been replaced with a simpler and more flexible API. You can read more about it here: [Godot to Bevy Communication](../scene-tree/godot-to-bevy-communication.md).
+
+
+## Overview
 
 This pattern is for teams migrating existing Godot/GDScript gameplay into `godot-bevy`.
 

--- a/book/src/scene-tree/godot-to-bevy-communication.md
+++ b/book/src/scene-tree/godot-to-bevy-communication.md
@@ -1,0 +1,106 @@
+# Godot to Bevy Events/Messages
+
+Sometimes we need to communicate from Godot to Bevy.
+For example, we might want a button press to trigger the game to start.
+
+This approach leverages the `godot_bevy::app::with_bevy_app_singleton()` helper function.
+With it, we can access the Bevy App object from any Godot node attached to the scene tree.
+In our example, we call it from the button-pressed signal handler of our `StartGameButton` node.
+`with_bevy_app_singleton` is only accessible from Rust code, so we need to define a
+custom Godot node.
+
+First, let's define our custom Godot node. Any type that extends Node will work:
+```rust,ignore
+#[derive(GodotClass)]
+#[class(base=Button, init)]
+pub struct StartGameButton {
+    base: Base<Button>,
+}
+```
+
+Next, we will implement the `IButton` trait, and add a signal handler for the `pressed` signal.
+```rust,ignore
+#[godot_api]
+impl IButton for StartGameButton {
+    fn ready(&mut self) {
+        self.signals()
+            .pressed()
+            .connect_self(Self::on_button_pressed);
+    }
+}
+
+#[godot_api]
+impl StartGameButton {
+    pub fn on_button_pressed(&mut self) {
+        // ...signal handler code...
+    }
+}
+```
+
+We are now ready to define our Bevy event. Messages will work as well.
+You can read about the differences between events and messages on
+[taintedcoders's helpful blog about them](https://taintedcoders.com/bevy/events).
+```rust,ignore
+#[derive(Event)]
+pub struct StartGameEvent;
+```
+
+Now we can implement our signal handler.
+```rust,ignore
+    pub fn on_button_pressed(&mut self) {
+        with_bevy_app_singleton(&self.base(), |app| {
+            // Sends the StartGameEvent to the Bevy App where it can be handled by a system.
+            app.world_mut().trigger(StartGameEvent);
+        });
+    }
+```
+
+Here's an example of what a Bevy event handler might look like.
+```rust,ignore
+pub fn trigger_level_generation_step(
+    event: On<StartGameEvent>,
+    mut parameters_query: Query<(&mut LevelGeneratorParameters, &GodotNodeHandle), With<GridMapMarker>>,
+    mut godot: GodotAccess,
+) {
+    debug!("Starting game! Generating level...");
+}
+```
+
+
+
+## Full Example
+
+```rust,ignore
+use bevy::prelude::Event;
+use godot::classes::{Button, IButton};
+use godot::obj::{Base, WithBaseField, WithUserSignals};
+use godot::prelude::{GodotClass, godot_api};
+use godot_bevy::app::with_bevy_app_singleton;
+
+#[derive(Event)]
+pub struct StartGameEvent;
+
+#[derive(GodotClass)]
+#[class(base=Button, init)]
+pub struct StartGameButton {
+    base: Base<Button>,
+}
+
+#[godot_api]
+impl IButton for StartGameButton {
+    fn ready(&mut self) {
+        self.signals()
+            .pressed()
+            .connect_self(Self::on_button_pressed);
+    }
+}
+
+#[godot_api]
+impl StartGameButton {
+    pub fn on_button_pressed(&mut self) {
+        with_bevy_app_singleton(&self.base(), |app| {
+            app.world_mut().trigger(StartGameEvent);
+        });
+    }
+}
+```

--- a/book/src/scene-tree/index.md
+++ b/book/src/scene-tree/index.md
@@ -3,3 +3,4 @@
 - [Initialization and Timing](timing.md)
 - [Querying with Node Type Markers](querying.md)
 - [Custom Nodes](custom-nodes/index.md)
+- [Godot to Bevy Communication](godot-to-bevy-communication.md)

--- a/godot-bevy/src/app.rs
+++ b/godot-bevy/src/app.rs
@@ -11,6 +11,7 @@ use crate::watchers::scene_tree_watcher::SceneTreeWatcher;
 use bevy_app::{App, PluginsState};
 use bevy_ecs::message::Messages;
 use crossbeam_channel::unbounded;
+use godot::obj::WithBaseField;
 use godot::prelude::*;
 use std::sync::OnceLock;
 
@@ -258,6 +259,16 @@ impl BevyApp {
             app.init_non_send_resource::<BulkOperationsCache>();
         }
     }
+
+    /// Allows access to the Bevy App object for this BevyApp.
+    /// Useful for communicating with Bevy systems from Godot nodes.
+    pub fn bevy_app_access(&mut self, func: impl FnOnce(&mut App)) {
+        if let Some(app) = self.app.as_mut() {
+            func(app);
+        } else {
+            tracing::warn!("BevyApp not yet initialized or panicked");
+        }
+    }
 }
 
 #[godot_api]
@@ -338,4 +349,53 @@ impl INode for BevyApp {
             resume_unwind(e);
         }
     }
+}
+
+/// Allows access to the Bevy App object for the BevyApp located in the `BevyAppSingleton` autoload node.
+/// This is useful for communicating with Bevy systems from Godot nodes.
+///
+/// Parameters:
+/// - `node`: Typically `&self.base()` of the calling node. The node must be attached to the scene tree for node path resolution to work.
+/// - `func`: A closure that will be passed a mutable reference to the Bevy App.
+///
+/// This example shows how to use `with_bevy_app_singleton` from a custom Button node to trigger a Bevy event:
+/// ```rust,ignore
+/// use bevy::prelude::Event;
+/// use godot::classes::{Button, IButton};
+/// use godot::obj::{Base, WithBaseField, WithUserSignals};
+/// use godot::prelude::{GodotClass, godot_api};
+/// use godot_bevy::app::with_bevy_app_singleton;
+///
+/// #[derive(Event)]
+/// pub struct StartGameEvent;
+///
+/// #[derive(GodotClass)]
+/// #[class(base=Button, init)]
+/// pub struct StartGameButton {
+///     base: Base<Button>,
+/// }
+///
+/// #[godot_api]
+/// impl IButton for StartGameButton {
+///     fn ready(&mut self) {
+///         self.signals()
+///             .pressed()
+///             .connect_self(Self::on_button_pressed);
+///     }
+/// }
+///
+/// #[godot_api]
+/// impl StartGameButton {
+///     pub fn on_button_pressed(&mut self) {
+///         with_bevy_app_singleton(&self.base(), |app| {
+///             app.world_mut().trigger(StartGameEvent);
+///         });
+///     }
+/// }
+/// ```
+pub fn with_bevy_app_singleton(node: &Node, func: impl FnOnce(&mut App)) {
+    let Some(mut bevy_app) = node.try_get_node_as::<BevyApp>("/root/BevyAppSingleton") else {
+        return;
+    };
+    bevy_app.bind_mut().bevy_app_access(func);
 }

--- a/godot-bevy/src/plugins/mailbox.rs
+++ b/godot-bevy/src/plugins/mailbox.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use crate::interop::{GodotAccess, GodotNodeHandle};
 use crate::plugins::core::PhysicsUpdate;
 use bevy_app::{App, Plugin};
@@ -11,6 +12,7 @@ use std::marker::PhantomData;
 
 /// Marker set for Godot mailbox drain systems.
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+#[deprecated(note = "Use `with_bevy_app_singleton()` for simpler and more functional API.")]
 pub enum GodotMailboxSet {
     /// Reads script-side mailbox state from Godot nodes and emits Bevy messages.
     Drain,
@@ -21,6 +23,7 @@ pub enum GodotMailboxSet {
 /// A message type decides how to read and clear its own script-side mailbox fields.
 /// This allows bridging legacy script writes into typed ECS messages without coupling
 /// games to stringly-typed ad-hoc systems.
+#[deprecated(note = "Use `with_bevy_app_singleton()` for simpler and more functional API.")]
 pub trait GodotMailboxMessage: Message + Send + Sync + Sized + 'static {
     /// Reads this message from a Godot node (if pending), and clears pending data as needed.
     fn drain_from_node(node: &mut Node, source: GodotNodeHandle) -> Option<Self>;
@@ -29,6 +32,7 @@ pub trait GodotMailboxMessage: Message + Send + Sync + Sized + 'static {
 /// Generic plugin that drains mailbox messages from Godot nodes with marker `Marker`.
 ///
 /// This plugin runs in [`PhysicsUpdate`] and writes messages of type `T`.
+#[deprecated(note = "Use `with_bevy_app_singleton()` for simpler and more functional API.")]
 pub struct GodotMailboxPlugin<T, Marker>
 where
     T: GodotMailboxMessage,
@@ -62,6 +66,7 @@ where
     }
 }
 
+#[deprecated(note = "Use `with_bevy_app_singleton()` for simpler and more functional API.")]
 fn drain_mailbox_messages<T, Marker>(
     nodes: Query<&GodotNodeHandle, With<Marker>>,
     mut writer: MessageWriter<T>,

--- a/godot-bevy/src/plugins/mod.rs
+++ b/godot-bevy/src/plugins/mod.rs
@@ -25,6 +25,7 @@ pub use debugger::{DebuggerConfig, GodotDebuggerPlugin};
 #[cfg(feature = "godot_bevy_log")]
 pub use godot_bevy_logger::GodotBevyLogPlugin;
 pub use input::{BevyInputBridgePlugin, GodotInputEventPlugin};
+#[allow(deprecated)]
 pub use mailbox::{GodotMailboxMessage, GodotMailboxPlugin, GodotMailboxSet};
 pub use packed_scene::GodotPackedScenePlugin;
 pub use scene_tree::GodotSceneTreePlugin;

--- a/godot-bevy/src/prelude.rs
+++ b/godot-bevy/src/prelude.rs
@@ -3,6 +3,7 @@ pub use crate::interop::*;
 pub use crate::node_tree_view::{NodeTreeView, NodeTreeViewError};
 #[cfg(feature = "godot_bevy_log")]
 pub use crate::plugins::godot_bevy_logger::GodotBevyLogPlugin;
+#[allow(deprecated)]
 pub use crate::plugins::{
     GodotCorePlugins,
     GodotDefaultPlugins,


### PR DESCRIPTION
## Description

#### What was changed:
<!-- Describe what you changed. -->
Added method `BevyApp::bevy_app_access` to allow access to the Bevy App object.
Added helper function `with_bevy_app_singleton` to access the Bevy App on the BevyAppSingleton node.

#### Why it was changed:
<!-- Describe why you changed it. -->
Responding to Godot signals was challenging because of the amount of boilerplate required with other solutions.
These changes also open up possibilities for other Bevy App interactions like updating resources.

## Checklist

- [x] Create awesomeness!
- [x] Update book (if needed)
  - [x] Update migration guide (if breaking change)
  - [x] Run `mdbook test` (if book was updated)
- [ ] Add/update tests (if needed)
- [ ] Update examples (if needed)
- [ ] Run examples
- [x] Run `cargo fmt --all`
- [x] Run `cargo clippy`
