### PR TITLE
feat(profiling): Separate Tracy port for Godot editor and game

### DIFF
--- a/book/src/profiling/profiling.md
+++ b/book/src/profiling/profiling.md
@@ -46,3 +46,5 @@ trace_tracy = ["dep:tracing-tracy", "godot-bevy/trace_tracy"]
 ## Notes
 
 > **Note for version 0.9.3+**: The `check-cfg` workaround is no longer needed. Tracy integration has been refactored to prevent dependency leaks.
+
+> **Note for version 0.12.0+**: The Godot editor uses a different Tracy client port than game instances. The default editor port is `7867`. It can be overridden by setting the `GODOT_EDITOR_TRACY_PORT=7867` environment variable. You override the game instance Tracy port as usual with `TRACY_PORT=8086`.

--- a/godot-bevy/src/profiling.rs
+++ b/godot-bevy/src/profiling.rs
@@ -17,8 +17,28 @@ static TRACY_CLIENT: Lazy<tracing_tracy::client::Client> =
 pub fn init_profiler() {
     #[cfg(feature = "trace_tracy")]
     {
+        use godot::obj::Singleton;
+        let original_port = godot::classes::Os::singleton().get_environment("TRACY_PORT");
+        let editor_port =
+            godot::classes::Os::singleton().get_environment("GODOT_EDITOR_TRACY_PORT");
+        let editor_port = if editor_port.is_empty() {
+            godot::builtin::GString::from("7867")
+        } else {
+            editor_port
+        };
+
+        // Start Godot editor Tracy client on different port than game instances
+        // so the editor and game can be profiled separately
+        if godot::classes::Engine::singleton().is_editor_hint() {
+            // Set port before tracy client initialization
+            godot::classes::Os::singleton().set_environment("TRACY_PORT", &editor_port);
+        }
+
         // Force Tracy client initialization
         let _ = &*TRACY_CLIENT;
+
+        // Restore original port for game instances
+        godot::classes::Os::singleton().set_environment("TRACY_PORT", &original_port);
 
         // Optional: Set up tracing subscriber with Tracy layer
         // This could be done elsewhere if needed


### PR DESCRIPTION
## Description

The Godot editor would prevent me from profiling my game with Tracy, so I added a feature to allow the Godot editor to use a different TRACY_PORT.

## Checklist

- [x] Create awesomeness!
- [x] Update book (if needed)
  - [ ] Update migration guide (if breaking change)
  - [ ] Run `mdbook test` (if book was updated)
- [ ] Add/update tests (if needed)
- [ ] Update examples (if needed)
- [ ] Run examples
- [x] Run `cargo fmt --all`
- [x] Run `cargo clippy`

## Related Issues

Closes #[issue_number]
