### PR TITLE
feat(deps): Enables gdext api 4.6

### DIFF
--- a/godot-bevy/Cargo.toml
+++ b/godot-bevy/Cargo.toml
@@ -61,6 +61,7 @@ api-4-2 = ["godot/api-4-2"]
 api-4-3 = ["godot/api-4-3"]
 api-4-4 = ["godot/api-4-4"]
 api-4-5 = ["godot/api-4-5"]
+api-4-6 = ["godot/api-4-6"]
 experimental-godot-api = ["godot/experimental-godot-api"]
 # Web/WASM support (experimental)
 # Note: These features intentionally exclude bevy_gamepad, godot_bevy_log,


### PR DESCRIPTION
## Description

I simply created the feature `"api-4-6"` reflecting godot's `"api-4-6"`.
My project is using a vendored version of this library because we use Godot 4.6
## Checklist

- [x] Create awesomeness!
