### PR TITLE
Naomijub/upstreaming changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  GODOT_VERSION: "4.6.2"
+  GODOT_VERSION: "4.6.3"
   GDENV_VERSION: "0.2.2"
 
 permissions:

--- a/book/src/getting-started/basic-concepts.md
+++ b/book/src/getting-started/basic-concepts.md
@@ -87,6 +87,16 @@ This macro:
 3. Integrates with Godot's lifecycle
 4. Handles all the bridging magic
 
+### Shutdown lifecycle
+
+When a `BevyApp` node leaves the Godot scene tree, godot-bevy writes
+`AppExit::Success` and runs Bevy's `Last` schedule before tearing down the embedded
+app. Use `Last` systems for per-instance cleanup that must run when that node exits.
+
+The extension's `on_stage_deinit` hook is a separate process-level lifecycle event;
+it shuts down extension-wide services such as profiling and is not a replacement for
+per-`BevyApp` shutdown.
+
 ### Configuring Core Behavior
 
 The `#[bevy_app]` macro accepts configuration attributes to customize godot-bevy's core behavior:

--- a/book/src/scene-tree/custom-nodes/property-mapping-with-bevy-bundle.md
+++ b/book/src/scene-tree/custom-nodes/property-mapping-with-bevy-bundle.md
@@ -37,6 +37,24 @@ pub struct Enemy;
 
 Each inner `field(as = T, …)` follows the same `as`/`default`/`with` grammar as the newtype form. The name before `:` (e.g. `stats`) is required by the grammar but ignored — the generated export properties use the inner field names (`health`, `mana`).
 
+### Inspector metadata for generated exports
+
+Generated exports can carry Inspector metadata:
+
+```rust
+#[gdbevy(require(
+    kind: WeaponKind,
+    as = String,
+    description = "Weapon selected by the designer",
+    hint = ENUM,
+    hint_string = "Hands,Knife"
+))]
+```
+
+`description` becomes the Godot property description. `hint` names a Godot
+`PropertyHint` variant, and `hint_string` supplies its optional string. A
+`hint_string` requires `hint`.
+
 ### Marker companion
 
 Insert a component via `Default` with no exported property:
@@ -138,6 +156,10 @@ pub struct PlayerNode {
 | struct | `require(Comp { bevy_field: godot_field, … })` | no | Build struct component from existing exports |
 | field | `component = Comp` | **yes** | Bevy component type (`Comp(value)`) |
 | field | `with = fn` | no | Godot-value → component-value conversion |
+
+Godot-first classes own their gdext declaration, so use gdext's native
+`#[var(hint = ..., hint_string = ...)]` and Rust documentation attributes for
+Inspector metadata on those fields.
 
 ## Reserved keys
 

--- a/godot-bevy-macros/src/bevy_attr.rs
+++ b/godot-bevy-macros/src/bevy_attr.rs
@@ -4,8 +4,8 @@ use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{
-    Attribute, Data, DeriveInput, Error, Expr, Field, Fields, Ident, Meta, Path, Token, Type,
-    braced, parenthesized, parse_quote,
+    Attribute, Data, DeriveInput, Error, Expr, Field, Fields, Ident, LitStr, Meta, Path, Token,
+    Type, braced, parenthesized, parse_quote,
 };
 
 /// The Godot class + Bevy components a single derive expands to.
@@ -46,6 +46,10 @@ pub struct Mapping {
     pub as_type: Option<syn::Type>,
     pub default: Option<syn::Expr>,
     pub with: Option<syn::Path>,
+    pub docs: Vec<Attribute>,
+    pub description: Option<LitStr>,
+    pub hint: Option<Ident>,
+    pub hint_string: Option<Expr>,
 }
 
 // Summary Debug so tests can `.unwrap_err()` on `Result<ClassPlan, _>`;
@@ -72,6 +76,9 @@ struct Directives {
     with: Option<Path>,
     component: Option<Path>,
     export: bool,
+    description: Option<LitStr>,
+    hint: Option<Ident>,
+    hint_string: Option<Expr>,
 }
 
 fn parse_directives(input: ParseStream) -> syn::Result<Directives> {
@@ -109,6 +116,27 @@ fn parse_directives(input: ParseStream) -> syn::Result<Directives> {
                     }
                     d.with = Some(input.parse()?);
                 }
+                "description" => {
+                    input.parse::<Token![=]>()?;
+                    if d.description.is_some() {
+                        return Err(Error::new(key.span(), "duplicate `description`"));
+                    }
+                    d.description = Some(input.parse()?);
+                }
+                "hint" => {
+                    input.parse::<Token![=]>()?;
+                    if d.hint.is_some() {
+                        return Err(Error::new(key.span(), "duplicate `hint`"));
+                    }
+                    d.hint = Some(input.parse()?);
+                }
+                "hint_string" => {
+                    input.parse::<Token![=]>()?;
+                    if d.hint_string.is_some() {
+                        return Err(Error::new(key.span(), "duplicate `hint_string`"));
+                    }
+                    d.hint_string = Some(input.parse()?);
+                }
                 "component" => {
                     input.parse::<Token![=]>()?;
                     if d.component.is_some() {
@@ -126,7 +154,7 @@ fn parse_directives(input: ParseStream) -> syn::Result<Directives> {
                     return Err(Error::new(
                         key.span(),
                         format!(
-                            "unknown key `{name}`; expected `as`, `default`, `with`, `component`, or `export`"
+                            "unknown key `{name}`; expected `as`, `default`, `with`, `description`, `hint`, `hint_string`, `component`, or `export`"
                         ),
                     ));
                 }
@@ -138,7 +166,22 @@ fn parse_directives(input: ParseStream) -> syn::Result<Directives> {
             break;
         }
     }
+    if d.hint_string.is_some() && d.hint.is_none() {
+        return Err(Error::new(
+            input.span(),
+            "`hint_string` requires `hint` to also be provided",
+        ));
+    }
     Ok(d)
+}
+
+fn doc_attributes(field: &Field) -> Vec<Attribute> {
+    field
+        .attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("doc"))
+        .cloned()
+        .collect()
 }
 
 /// The syntactic shape of one `require(...)` entry, before front-end validation.
@@ -368,6 +411,10 @@ fn cf_companion(raw: RawRequire) -> syn::Result<ComponentPlan> {
                     as_type: Some(as_type),
                     default: cfg.default,
                     with: cfg.with,
+                    docs: Vec::new(),
+                    description: cfg.description,
+                    hint: cfg.hint,
+                    hint_string: cfg.hint_string,
                 }),
             })
         }
@@ -392,6 +439,10 @@ fn cf_companion(raw: RawRequire) -> syn::Result<ComponentPlan> {
                     as_type: Some(as_type),
                     default: cfg.default,
                     with: cfg.with,
+                    docs: Vec::new(),
+                    description: cfg.description,
+                    hint: cfg.hint,
+                    hint_string: cfg.hint_string,
                 });
             }
             Ok(ComponentPlan {
@@ -431,6 +482,10 @@ fn gf_companion(raw: RawRequire) -> syn::Result<ComponentPlan> {
                     as_type: None,
                     default: None,
                     with: None,
+                    docs: Vec::new(),
+                    description: None,
+                    hint: None,
+                    hint_string: None,
                 })
                 .collect();
             Ok(ComponentPlan {
@@ -468,6 +523,10 @@ fn collect_primary_fields(input: &DeriveInput) -> syn::Result<Vec<Mapping>> {
             as_type: d.as_type,
             default: d.default,
             with: d.with,
+            docs: doc_attributes(field),
+            description: d.description,
+            hint: d.hint,
+            hint_string: d.hint_string,
         });
     }
     Ok(out)
@@ -499,6 +558,12 @@ fn collect_field_bindings(input: &DeriveInput) -> syn::Result<Vec<ComponentPlan>
                 "`export` is not valid on a Godot-first field binding",
             ));
         }
+        if d.description.is_some() || d.hint.is_some() || d.hint_string.is_some() {
+            return Err(Error::new_spanned(
+                attr,
+                "`description`, `hint`, and `hint_string` are only valid on generated component-first exports",
+            ));
+        }
         let Some(component) = d.component else {
             return Err(Error::new_spanned(
                 attr,
@@ -514,6 +579,10 @@ fn collect_field_bindings(input: &DeriveInput) -> syn::Result<Vec<ComponentPlan>
                 as_type: None,
                 default: None,
                 with: d.with,
+                docs: Vec::new(),
+                description: d.description,
+                hint: d.hint,
+                hint_string: d.hint_string,
             }),
         });
     }
@@ -931,5 +1000,42 @@ mod tests {
                 .to_string()
                 .contains("not yet available")
         );
+    }
+
+    #[test]
+    fn hint_string_requires_hint() {
+        let di: syn::DeriveInput = parse_quote! {
+            #[derive(Component, GodotNode)]
+            #[gdbevy(require(speed: Speed, as = f32, hint_string = "one"))]
+            struct Player;
+        };
+        assert!(
+            parse_component_first(&di)
+                .unwrap_err()
+                .to_string()
+                .contains("`hint_string` requires `hint`")
+        );
+    }
+
+    #[test]
+    fn parses_export_description_and_hint() {
+        let di: syn::DeriveInput = parse_quote! {
+            #[derive(Component, GodotNode)]
+            #[gdbevy(require(
+                kind: Kind,
+                as = String,
+                description = "Weapon kind",
+                hint = ENUM,
+                hint_string = "Hands,Knife"
+            ))]
+            struct Player;
+        };
+        let plan = parse_component_first(&di).expect("valid export metadata");
+        let ComponentInit::Newtype(mapping) = &plan.companions[0].init else {
+            panic!("expected generated newtype mapping");
+        };
+        assert_eq!(mapping.description.as_ref().unwrap().value(), "Weapon kind");
+        assert_eq!(mapping.hint.as_ref().unwrap().to_string(), "ENUM");
+        assert!(mapping.hint_string.is_some());
     }
 }

--- a/godot-bevy-macros/src/emit.rs
+++ b/godot-bevy-macros/src/emit.rs
@@ -67,8 +67,24 @@ fn export_field(m: &Mapping, ty: Option<Type>) -> TokenStream2 {
         let val = paren_wrap(d);
         quote!(#[init(val = #val)])
     });
+    let docs = &m.docs;
+    let description = m
+        .description
+        .as_ref()
+        .map(|description| quote!(#[doc = #description]));
+    let hint = match (&m.hint, &m.hint_string) {
+        (Some(hint), Some(hint_string)) => {
+            quote!(#[var(hint = #hint, hint_string = #hint_string)])
+        }
+        (Some(hint), None) => quote!(#[var(hint = #hint)]),
+        (None, None) => quote!(),
+        (None, Some(_)) => unreachable!("`hint_string` is valid only with `hint`"),
+    };
     quote! {
+        #(#docs)*
+        #description
         #[export]
+        #hint
         #init
         #prop: #ty
     }
@@ -377,6 +393,50 @@ mod tests {
         assert!(out.contains("Player :: default ()"));
         assert!(!out.contains("GodotRequiredComponents")); // GF has no trigger
         assert!(!out.contains("bevy_bundle"));
+    }
+
+    #[test]
+    fn emits_docs_and_hints_for_generated_exports() {
+        let di: syn::DeriveInput = syn::parse_quote! {
+            #[derive(Component, GodotNode, Default)]
+            #[gdbevy(base = Node2D, class_name = WeaponNode)]
+            #[gdbevy(require(
+                kind: WeaponKind,
+                as = String,
+                description = "Weapon kind",
+                hint = ENUM,
+                hint_string = "Hands,Knife"
+            ))]
+            struct Weapon;
+        };
+        let out = crate::godot_node::derive_godot_node_component(di)
+            .unwrap()
+            .to_string();
+        assert!(out.contains("# [doc = \"Weapon kind\"]"));
+        assert!(out.contains("# [var (hint = ENUM , hint_string = \"Hands,Knife\")]"));
+    }
+
+    #[test]
+    fn forwards_field_docs_to_generated_exports() {
+        let di: syn::DeriveInput = syn::parse_quote! {
+            /// Player settings.
+            #[derive(Component, GodotNode, Default)]
+            #[gdbevy(base = Node2D, class_name = PlayerNode)]
+            struct Player {
+                /// Movement speed in pixels per second.
+                #[gdbevy(export)]
+                speed: f32,
+                /// Weapon kind
+                #[gdbevy(export, hint = ENUM, hint_string = "Hands,Knife")]
+                kind: String,
+            }
+        };
+        let out = crate::godot_node::derive_godot_node_component(di)
+            .unwrap()
+            .to_string();
+        assert!(out.contains("Movement speed in pixels per second."));
+        assert!(out.contains("Weapon kind"));
+        assert!(out.contains("# [var (hint = ENUM , hint_string = \"Hands,Knife\")]"));
     }
 
     #[test]

--- a/godot-bevy-macros/src/godot_hint_string.rs
+++ b/godot-bevy-macros/src/godot_hint_string.rs
@@ -1,0 +1,128 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Error, Fields, LitStr, Token, parse2};
+
+/// Build a Godot `PropertyHint::ENUM` string from a fieldless Rust enum.
+pub fn derive_godot_hint_string(input: TokenStream) -> syn::Result<TokenStream> {
+    let input = parse2::<DeriveInput>(input)?;
+    let enum_name = &input.ident;
+    let Data::Enum(data) = &input.data else {
+        return Err(Error::new_spanned(
+            &input.ident,
+            "GodotHintString can only be derived for enums",
+        ));
+    };
+
+    let mut labels = Vec::new();
+    for variant in &data.variants {
+        if !matches!(variant.fields, Fields::Unit) {
+            return Err(Error::new_spanned(
+                &variant.fields,
+                "GodotHintString only supports fieldless enum variants",
+            ));
+        }
+
+        let mut skip = false;
+        let mut label = None;
+        for attr in &variant.attrs {
+            if !attr.path().is_ident("godot_hint") {
+                continue;
+            }
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("skip") {
+                    if skip {
+                        return Err(meta.error("duplicate `skip`"));
+                    }
+                    skip = true;
+                    return Ok(());
+                }
+                if meta.path.is_ident("label") {
+                    if label.is_some() {
+                        return Err(meta.error("duplicate `label`"));
+                    }
+                    meta.input.parse::<Token![=]>()?;
+                    label = Some(meta.input.parse::<LitStr>()?);
+                    return Ok(());
+                }
+                Err(meta.error("expected `skip` or `label = \"...\"`"))
+            })?;
+        }
+
+        if skip && label.is_some() {
+            return Err(Error::new_spanned(
+                &variant.ident,
+                "`skip` and `label` cannot be used together",
+            ));
+        }
+        if !skip {
+            labels.push(
+                label.unwrap_or_else(|| {
+                    LitStr::new(&variant.ident.to_string(), variant.ident.span())
+                }),
+            );
+        }
+    }
+
+    let hint_string = labels
+        .iter()
+        .map(LitStr::value)
+        .collect::<Vec<_>>()
+        .join(",");
+    let hint_string = LitStr::new(&hint_string, enum_name.span());
+
+    Ok(quote! {
+        impl #enum_name {
+            pub const GODOT_HINT_STRING: &'static str = #hint_string;
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::derive_godot_hint_string;
+    use quote::{ToTokens, quote};
+    use syn::DeriveInput;
+
+    #[test]
+    fn uses_variant_names_by_default() {
+        let input: DeriveInput = syn::parse2(quote! {
+            enum WeaponKind { Hands, Knife }
+        })
+        .unwrap();
+        let output = derive_godot_hint_string(input.into_token_stream()).unwrap();
+        assert!(
+            output
+                .to_string()
+                .contains("GODOT_HINT_STRING : & 'static str = \"Hands,Knife\"")
+        );
+    }
+
+    #[test]
+    fn supports_custom_labels_and_skipped_variants() {
+        let input: DeriveInput = syn::parse2(quote! {
+            enum WeaponKind {
+                Hands,
+                #[godot_hint(label = "Assault Rifle")]
+                Rifle,
+                #[godot_hint(skip)]
+                Removed,
+            }
+        })
+        .unwrap();
+        let output = derive_godot_hint_string(input.into_token_stream()).unwrap();
+        assert!(
+            output
+                .to_string()
+                .contains("GODOT_HINT_STRING : & 'static str = \"Hands,Assault Rifle\"")
+        );
+    }
+
+    #[test]
+    fn rejects_data_variants() {
+        let input: DeriveInput = syn::parse2(quote! {
+            enum Invalid { Good, Bad(u8) }
+        })
+        .unwrap();
+        assert!(derive_godot_hint_string(input.into_token_stream()).is_err());
+    }
+}

--- a/godot-bevy-macros/src/lib.rs
+++ b/godot-bevy-macros/src/lib.rs
@@ -292,7 +292,8 @@ pub fn derive_bevy_components_entry(item: TokenStream) -> TokenStream {
 ///
 /// ## Reserved keys
 ///
-/// `into` and `sync` remain reserved for future mapping features and produce a compile error.
+/// `into` and `sync` are reserved for the deferred component-sync feature and will produce
+/// a compile error if used.
 #[proc_macro_derive(GodotNode, attributes(gdbevy))]
 pub fn component_as_godot_node(input: TokenStream) -> TokenStream {
     let parsed: DeriveInput = parse_macro_input!(input as DeriveInput);

--- a/godot-bevy-macros/src/lib.rs
+++ b/godot-bevy-macros/src/lib.rs
@@ -170,6 +170,7 @@ pub fn derive_node_tree_view(item: TokenStream) -> TokenStream {
 /// - `component = Comp` (**required**) — the Bevy component type to insert.
 /// - `with = fn` — a function `fn(T) -> T` (or any `Into` adapter) applied to the Godot
 ///   value before it is passed to the component constructor.
+/// - `hint = NAME` and `hint_string = expr` configure the Godot Inspector property hint.
 /// - `as` and `default` are **not** allowed on Godot-first field bindings.
 ///
 /// ## Struct-level companions
@@ -283,11 +284,15 @@ pub fn derive_bevy_components_entry(item: TokenStream) -> TokenStream {
 /// | `as = T` | Godot export type (defaults to the field's Rust type when omitted). |
 /// | `default = expr` | Editor default value passed to `#[init(val = …)]`. A pure-Bevy `spawn(T)` uses the struct's own `Default` — make them agree if you rely on `spawn(T)`. |
 /// | `with = fn` | Converts the Godot export value before assigning to the field. |
+/// | `description = "..."` | Adds an Inspector description for generated `require(...)` exports. |
+/// | `hint = NAME` | Sets the Godot `PropertyHint` variant. |
+/// | `hint_string = expr` | Supplies the hint string; requires `hint = NAME`. |
+///
+/// Rust `///` comments on primary exported fields are forwarded as Godot property descriptions.
 ///
 /// ## Reserved keys
 ///
-/// `into` and `sync` are reserved for the deferred component-sync feature and will produce
-/// a compile error if used.
+/// `into` and `sync` remain reserved for future mapping features and produce a compile error.
 #[proc_macro_derive(GodotNode, attributes(gdbevy))]
 pub fn component_as_godot_node(input: TokenStream) -> TokenStream {
     let parsed: DeriveInput = parse_macro_input!(input as DeriveInput);

--- a/godot-bevy/src/app.rs
+++ b/godot-bevy/src/app.rs
@@ -4,7 +4,7 @@ use crate::plugins::{
 use crate::watchers::collision_watcher::CollisionWatcher;
 use crate::watchers::input_watcher::GodotInputWatcher;
 use crate::watchers::scene_tree_watcher::SceneTreeWatcher;
-use bevy_app::{App, PluginsState};
+use bevy_app::{App, AppExit, Last, PluginsState};
 use bevy_ecs::message::Messages;
 use crossbeam_channel::unbounded;
 use godot::prelude::*;
@@ -465,6 +465,18 @@ impl INode for BevyApp {
         }
 
         self.do_initialize();
+    }
+
+    /// Give Bevy's final schedule a chance to observe shutdown before Godot
+    /// releases this node and the embedded app is dropped.
+    fn exit_tree(&mut self) {
+        if let Some(app) = self.app.as_mut() {
+            app.world_mut().write_message(AppExit::Success);
+            app.world_mut().run_schedule(Last);
+        }
+        // `teardown` clears `self.app`, so a later explicit teardown or a
+        // duplicate Godot notification is harmless and cannot run `Last` twice.
+        self.teardown();
     }
 
     #[tracing::instrument(skip_all)]

--- a/godot-bevy/src/app.rs
+++ b/godot-bevy/src/app.rs
@@ -467,15 +467,12 @@ impl INode for BevyApp {
         self.do_initialize();
     }
 
-    /// Give Bevy's final schedule a chance to observe shutdown before Godot
-    /// releases this node and the embedded app is dropped.
+    /// Allows Bevy to properly cleanup resources before Godot fully removes from tree
     fn exit_tree(&mut self) {
         if let Some(app) = self.app.as_mut() {
             app.world_mut().write_message(AppExit::Success);
             app.world_mut().run_schedule(Last);
         }
-        // `teardown` clears `self.app`, so a later explicit teardown or a
-        // duplicate Godot notification is harmless and cannot run `Last` twice.
         self.teardown();
     }
 

--- a/itest/rust/src/lib.rs
+++ b/itest/rust/src/lib.rs
@@ -22,6 +22,7 @@ mod pause_tests;
 mod real_frame_tests;
 mod scene_tree_tests;
 mod scene_tree_watcher_init_tests;
+mod shutdown_tests;
 mod signal_tests;
 mod time_scale_tests;
 mod transform_sync_tests;

--- a/itest/rust/src/macro_redesign_tests.rs
+++ b/itest/rust/src/macro_redesign_tests.rs
@@ -17,7 +17,14 @@ struct TestGrounded;
 
 #[derive(Component, GodotNode, Default)]
 #[gdbevy(base = Node2D, class_name = AutoSyncPlayerNode)]
-#[gdbevy(require(TestGrounded), require(speed: TestSpeed, as = f32, default = 250.0))]
+#[gdbevy(require(TestGrounded), require(
+    speed: TestSpeed,
+    as = f32,
+    default = 250.0,
+    description = "Movement speed",
+    hint = RANGE,
+    hint_string = "0,1000,1"
+))]
 struct AutoSyncPlayer;
 
 #[itest(async)]

--- a/itest/rust/src/shutdown_tests.rs
+++ b/itest/rust/src/shutdown_tests.rs
@@ -1,0 +1,58 @@
+use bevy::prelude::*;
+use godot::obj::NewAlloc;
+use godot::prelude::*;
+use godot_bevy::BevyApp;
+use godot_bevy_test::prelude::*;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+#[derive(Resource, Clone)]
+struct ExitCount(Arc<AtomicUsize>);
+
+/// A live BevyApp dispatches AppExit and runs Last exactly once when Godot
+/// removes it from the scene tree.
+#[itest(async)]
+fn test_bevy_app_exit_tree_runs_last_once(ctx: &TestContext) -> godot::task::TaskHandle {
+    let ctx_clone = ctx.clone();
+    godot::task::spawn(async move {
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_for_app = Arc::clone(&count);
+
+        let mut app = TestApp::new(&ctx_clone, |_| {}).await;
+
+        let mut node = BevyApp::new_alloc();
+        node.set_name("BevyAppShutdownProbe");
+        node.bind_mut()
+            .set_instance_init_func(Box::new(move |bevy_app: &mut App| {
+                bevy_app.insert_resource(ExitCount(Arc::clone(&count_for_app)));
+                bevy_app.add_systems(
+                    Last,
+                    |mut exits: MessageReader<AppExit>, count: Res<ExitCount>| {
+                        for _ in exits.read() {
+                            count.0.fetch_add(1, Ordering::SeqCst);
+                        }
+                    },
+                );
+            }));
+
+        ctx_clone
+            .scene_tree
+            .clone()
+            .add_child(&node.clone().upcast::<Node>());
+        node.bind_mut().initialize();
+
+        // Let initialization settle before removing the node.
+        app.update().await;
+        node.clone().upcast::<Node>().free();
+
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "exit_tree should dispatch AppExit and run Last exactly once"
+        );
+
+        app.cleanup().await;
+    })
+}


### PR DESCRIPTION
## Description

1. Ensures Bevy cleanup systems run reliably when a BevyApp leaves the Godot scene tree. why: This was causing Memory leaks in my project
2. Allows Godot Inspector properties to keep descriptions, type hints, and enum option labels. why: We were not able to view hints of the bevy types in Godot.

## Checklist

- [x] Create awesomeness!
- [x] Update book (if needed)
  - [ ] Update migration guide (if breaking change)
  - [ ] Run `mdbook test` (if book was updated)
- [x] Add/update tests (if needed)
- [ ] Update examples (if needed)
- [x] Run examples
- [x] Run `cargo fmt --all`
- [x] Run `cargo clippy`

