### PR TITLE
Add support for tuples and new-types

### DIFF
--- a/godot-bevy-macros/src/bevy_attr.rs
+++ b/godot-bevy-macros/src/bevy_attr.rs
@@ -8,6 +8,8 @@ use syn::{
     braced, parenthesized, parse_quote,
 };
 
+pub const TUPLE_FIELD_PREFIX: &str = "value";
+
 /// The Godot class + Bevy components a single derive expands to.
 ///
 /// Two front-ends share this IR: component-first (`GodotNode`, which generates the
@@ -306,10 +308,7 @@ fn struct_fields(input: &DeriveInput) -> syn::Result<Vec<&Field>> {
         Data::Struct(s) => match &s.fields {
             Fields::Named(n) => Ok(n.named.iter().collect()),
             Fields::Unit => Ok(Vec::new()),
-            Fields::Unnamed(_) => Err(Error::new_spanned(
-                input,
-                "tuple structs are not supported; use a named-field or unit struct",
-            )),
+            Fields::Unnamed(u) => Ok(u.unnamed.iter().collect()),
         },
         _ => Err(Error::new_spanned(input, "expected a struct")),
     }
@@ -444,11 +443,18 @@ fn gf_companion(raw: RawRequire) -> syn::Result<ComponentPlan> {
 
 fn collect_primary_fields(input: &DeriveInput) -> syn::Result<Vec<Mapping>> {
     let mut out = Vec::new();
-    for field in struct_fields(input)? {
+    for (i, field) in struct_fields(input)?.into_iter().enumerate() {
         let Some(attr) = find_bevy_attr(field) else {
             continue;
         };
-        let name = field.ident.clone().unwrap();
+        let (godot_prop, bevy_field) = match &field.ident {
+            Some(ident) => (ident.clone(), Some(ident.clone())),
+            None => {
+                // Map tuples to value0, value1, value2, ..., value{n}
+                let synthetic_ident = format_ident!("{TUPLE_FIELD_PREFIX}{i}");
+                (synthetic_ident.clone(), Some(synthetic_ident))
+            }
+        };
         let d = parse_field_directives(attr)?;
         if d.component.is_some() {
             return Err(Error::new_spanned(
@@ -463,8 +469,8 @@ fn collect_primary_fields(input: &DeriveInput) -> syn::Result<Vec<Mapping>> {
             ));
         }
         out.push(Mapping {
-            godot_prop: name.clone(),
-            bevy_field: Some(name),
+            godot_prop,
+            bevy_field,
             as_type: d.as_type,
             default: d.default,
             with: d.with,
@@ -475,11 +481,14 @@ fn collect_primary_fields(input: &DeriveInput) -> syn::Result<Vec<Mapping>> {
 
 fn collect_field_bindings(input: &DeriveInput) -> syn::Result<Vec<ComponentPlan>> {
     let mut out = Vec::new();
-    for field in struct_fields(input)? {
+    for (i, field) in struct_fields(input)?.into_iter().enumerate() {
         let Some(attr) = find_bevy_attr(field) else {
             continue;
         };
-        let name = field.ident.clone().unwrap();
+        let name = match &field.ident {
+            Some(ident) => ident.clone(),
+            None => format_ident!("{TUPLE_FIELD_PREFIX}{i}"),
+        };
         let d = parse_field_directives(attr)?;
         if d.as_type.is_some() {
             return Err(Error::new_spanned(

--- a/godot-bevy-macros/src/emit.rs
+++ b/godot-bevy-macros/src/emit.rs
@@ -1,4 +1,6 @@
-use crate::bevy_attr::{ClassPlan, ComponentInit, ComponentPlan, Mapping, PrimaryPlan};
+use crate::bevy_attr::{
+    ClassPlan, ComponentInit, ComponentPlan, Mapping, PrimaryPlan, TUPLE_FIELD_PREFIX,
+};
 use proc_macro2::{TokenStream as TokenStream2, TokenTree};
 use quote::{ToTokens, format_ident, quote};
 use std::collections::HashSet;
@@ -14,7 +16,7 @@ pub fn emit(plan: &ClassPlan, input: &DeriveInput) -> TokenStream2 {
     if plan.emit_node_class {
         out.extend(emit_node_class(plan, input));
     }
-    out.extend(emit_autosync(plan));
+    out.extend(emit_autosync(plan, input));
     if let Some(trigger) = &plan.trigger {
         let sibling = collect_require_idents(&input.attrs);
         out.extend(emit_required_registration(plan, trigger, &sibling));
@@ -76,12 +78,12 @@ fn export_field(m: &Mapping, ty: Option<Type>) -> TokenStream2 {
 
 /// The autosync `create_bundle_fn` + its `inventory::submit!`. Reads the editor-authored
 /// `#[export]` values off the node and inserts them as a direct component tuple.
-fn emit_autosync(plan: &ClassPlan) -> TokenStream2 {
+fn emit_autosync(plan: &ClassPlan, input: &DeriveInput) -> TokenStream2 {
     let class = &plan.godot_class;
     let fn_name = format_ident!("__create_{}_bundle", class.to_string().to_lowercase());
 
     let mut values: Vec<TokenStream2> = Vec::new();
-    if let Some(pv) = primary_value(&plan.primary) {
+    if let Some(pv) = primary_value(&plan.primary, input) {
         values.push(pv);
     }
     for c in &plan.companions {
@@ -113,7 +115,7 @@ fn emit_autosync(plan: &ClassPlan) -> TokenStream2 {
     }
 }
 
-fn primary_value(primary: &PrimaryPlan) -> Option<TokenStream2> {
+fn primary_value(primary: &PrimaryPlan, input: &DeriveInput) -> Option<TokenStream2> {
     if primary.path.segments.is_empty() {
         return None;
     }
@@ -121,8 +123,19 @@ fn primary_value(primary: &PrimaryPlan) -> Option<TokenStream2> {
     if primary.fields.is_empty() {
         return Some(quote!(#path::default()));
     }
-    let inits = primary.fields.iter().map(field_init);
-    Some(quote!(#path { #(#inits,)* ..Default::default() }))
+
+    let is_tuple = match &input.data {
+        Data::Struct(s) => matches!(s.fields, syn::Fields::Unnamed(_)),
+        _ => false,
+    };
+
+    if is_tuple {
+        let inits = primary.fields.iter().map(read_prop);
+        Some(quote!(#path( #(#inits),* )))
+    } else {
+        let inits = primary.fields.iter().map(field_init);
+        Some(quote!(#path { #(#inits,)* ..Default::default() }))
+    }
 }
 
 fn companion_value(c: &ComponentPlan) -> TokenStream2 {
@@ -260,10 +273,23 @@ fn primary_field_type(input: &DeriveInput, ident: &Ident) -> Option<Type> {
     let Data::Struct(s) = &input.data else {
         return None;
     };
-    s.fields
-        .iter()
-        .find(|f| f.ident.as_ref() == Some(ident))
-        .map(|f| f.ty.clone())
+    match &s.fields {
+        syn::Fields::Named(n) => n
+            .named
+            .iter()
+            .find(|f| f.ident.as_ref() == Some(ident))
+            .map(|f| f.ty.clone()),
+        syn::Fields::Unnamed(u) => {
+            let name = ident.to_string();
+            if let Some(idx_str) = name.strip_prefix(TUPLE_FIELD_PREFIX) {
+                if let Ok(idx) = idx_str.parse::<usize>() {
+                    return u.unnamed.iter().nth(idx).map(|f| f.ty.clone());
+                }
+            }
+            None
+        }
+        syn::Fields::Unit => None,
+    }
 }
 
 /// gdext parses `#[init(val = expr)]` as an attribute, so a top-level comma in `expr` would be


### PR DESCRIPTION
## Description

<!-- Describe what you changed. -->

This PR adds support for displaying Bevy component tuples / new-types in the godot editor.  Currently the ``GodotNode`` derive doesn't support unnamed fields.  A component that you would normally define in bevy such as:

```rs
#[derive(Component)]
pub struct Health(pub f64);
```

Cannot be displayed in the Godot editor as a node.  This PR adds such support! :)  Now it can be defined like:

```rs
#[derive(Component, GodotNode, Default)]
#[gdbevy(base = Node)]
pub struct Health(#[gdbevy(export, default = 100.)] pub f64);
```

And then it appears in the editor like:

<img width="1885" height="547" alt="image" src="https://github.com/user-attachments/assets/3af7938e-b47a-4e5a-be6d-3cf3592ef500" />

And every unnamed field gets prefixed with "value" followed by the number that matches Rust's default numbering (0, 1, 2, ..., n)

Example:

```rs
#[derive(Component, GodotNode, Default)]
#[gdbevy(base = Node)]
pub struct PositionOffset(
    #[gdbevy(export)] pub f64,
    #[gdbevy(export)] pub f64,
    #[gdbevy(export)] pub f64,
);
```

<img width="1919" height="693" alt="image" src="https://github.com/user-attachments/assets/b7d6c446-e02e-43bf-a7d8-1114a405991d" />

## Checklist

- [x] Create awesomeness!
- [ ] Update book (if needed)
  - [ ] Update migration guide (if breaking change)
  - [ ] Run `mdbook test` (if book was updated)
- [ ] Add/update tests (if needed)
- [ ] Update examples (if needed)
- [ ] Run examples
- [x] Run `cargo fmt --all`
- [x] Run `cargo clippy`
