### PR TITLE
godot-bevy-test: single-crate integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
               - 'Cargo.lock'
             itest:
               - 'itest/**'
+              - 'examples/platformer-2d/**'
               - '.github/workflows/ci.yml'
             qualification:
               - '.cargo/mutants.toml'
@@ -235,6 +236,12 @@ jobs:
         env:
           GODOT4_BIN: godot
         run: ./run-tests.sh ${{ matrix.profile == 'release' && '--release' || '' }} --json ../target/itest-${{ matrix.profile }}.json
+
+      - name: Run platformer integration tests
+        env:
+          GODOT4_BIN: godot
+          GODOT: godot
+        run: cargo run ${{ matrix.profile == 'release' && '--release' || '' }} --features itest --manifest-path examples/platformer-2d/rust/Cargo.toml
 
       - name: Upload integration test report
         # skipped under act: no artifact service locally (ACTIONS_RUNTIME_TOKEN)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,13 @@ jobs:
           GODOT4_BIN: godot
         run: ./run-tests.sh ${{ matrix.profile == 'release' && '--release' || '' }} --json ../target/itest-${{ matrix.profile }}.json
 
+      - name: Import platformer Godot project
+        # Headless import can segfault on exit once a GDExtension is loaded
+        # (godotengine/godot#111645). The .godot folder is written before that, so
+        # tolerate the exit status like run-tests.sh does; cargo-godot-lib then skips
+        # its own import.
+        run: godot --headless --path examples/platformer-2d/godot --import --quit || true
+
       - name: Run platformer integration tests
         env:
           GODOT4_BIN: godot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,18 +237,16 @@ jobs:
           GODOT4_BIN: godot
         run: ./run-tests.sh ${{ matrix.profile == 'release' && '--release' || '' }} --json ../target/itest-${{ matrix.profile }}.json
 
-      - name: Import platformer Godot project
-        # Headless import can segfault on exit once a GDExtension is loaded
-        # (godotengine/godot#111645). The .godot folder is written before that, so
-        # tolerate the exit status like run-tests.sh does; cargo-godot-lib then skips
-        # its own import.
-        run: godot --headless --path examples/platformer-2d/godot --import --quit || true
-
       - name: Run platformer integration tests
         env:
           GODOT4_BIN: godot
           GODOT: godot
-        run: cargo run ${{ matrix.profile == 'release' && '--release' || '' }} --features itest --manifest-path examples/platformer-2d/rust/Cargo.toml
+        # The first run also does the headless import, which can segfault on exit once a
+        # GDExtension is loaded (godotengine/godot#111645) after .godot is already written.
+        # Retrying once then skips the import and just runs the tests.
+        run: |
+          CMD="cargo run ${{ matrix.profile == 'release' && '--release' || '' }} --features itest --manifest-path examples/platformer-2d/rust/Cargo.toml"
+          $CMD || { test -d examples/platformer-2d/godot/.godot && $CMD; }
 
       - name: Upload integration test report
         # skipped under act: no artifact service locally (ACTIONS_RUNTIME_TOKEN)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3730,6 +3730,7 @@ dependencies = [
  "fastrand",
  "godot",
  "godot-bevy",
+ "godot-bevy-test",
 ]
 
 [[package]]

--- a/addons/godot-bevy/test/TestRunner.gd
+++ b/addons/godot-bevy/test/TestRunner.gd
@@ -1,4 +1,4 @@
-# Copy this file and TestRunner.tscn to your test project's godot/ directory.
+# Launch this scene from the installed addon with --scene; copying is not needed.
 # If you used a custom name with declare_test_runner!(CustomName),
 # update test_class_name to match.
 

--- a/book-tests/src/doctest_scaffolds.rs
+++ b/book-tests/src/doctest_scaffolds.rs
@@ -174,7 +174,7 @@ mod itest {
 
     #[itest]
     async fn my_test(ctx: TestContext) {
-        let mut app = TestApp::new(&ctx, |_| {}).await;
+        let app = TestApp::new(&ctx, |_| {}).await;
         app.update().await;
     }
 

--- a/book-tests/src/doctest_scaffolds.rs
+++ b/book-tests/src/doctest_scaffolds.rs
@@ -173,6 +173,12 @@ mod itest {
     use godot_bevy_test::prelude::*;
 
     #[itest]
+    async fn my_test(ctx: TestContext) {
+        let mut app = TestApp::new(&ctx, |_| {}).await;
+        app.update().await;
+    }
+
+    #[itest]
     fn my_sync_test(_ctx: &TestContext) {}
 
     #[itest(async)]

--- a/book/src/getting-started/gdenv.md
+++ b/book/src/getting-started/gdenv.md
@@ -28,7 +28,7 @@ godot-bevy-test = { version = "0.11", optional = true }
 # Update or add your features section with:
 [features]
 # Add godot-bevy-test if you want to also set up integration tests
-itest = ["dep:godot-bevy-test"]
+itest = ["dep:godot-bevy-test", "godot-bevy-test/test-frame-signal"]
 ```
 
 Create a new `run_godot.rs` file. Put it at the same folder level as `Cargo.toml`.
@@ -46,10 +46,14 @@ fn main() {
 // Run with `cargo run --features itest` to run integration tests
 #[cfg(feature = "itest")]
 fn main() {
+    unsafe { std::env::set_var("GODOT_BEVY_ITEST", "1") };
+
     gdenv_lib::api::godot_runner::GodotRunner::init()
         .and_then(|r| {
             r.godot_cli_arguments(Some(vec![
                 "--headless".to_string(),
+                "--fixed-fps".to_string(),
+                "60".to_string(),
                 "--scene".to_string(),
                 "res://addons/godot-bevy/test/TestRunner.tscn".to_string(),
                 "--quit-after".to_string(),

--- a/book/src/testing/index.md
+++ b/book/src/testing/index.md
@@ -1,332 +1,118 @@
 # Integration Testing
 
-Testing game logic can be tricky. Unit tests work great for pure Rust functions, but godot-bevy code interacts deeply with both Godot's runtime and Bevy's ECS. That's where integration testing comes in.
+Integration tests run game code in Godot with real frame progression. Use them when a system depends on the scene tree, Godot nodes, or Godot's frame loop. Pure Rust logic is still a good fit for unit tests.
 
-The `godot-bevy-test` crate provides a framework for writing tests that run inside Godot with real frame progression. Your tests have full access to both Bevy's ECS and Godot's scene tree, letting you verify that your game logic actually works in the runtime environment.
+## Project layout
 
-## Why Integration Tests?
+Tests live in the game crate and run in its Godot project:
 
-Consider testing a player movement system:
-
-```rust
-fn player_movement(
-    time: Res<Time>,
-    mut query: Query<(&mut Transform, &GodotNodeHandle), With<Player>>,
-) {
-    for (mut transform, handle) in query.iter_mut() {
-        transform.translation.x += 100.0 * time.delta_secs();
-    }
-}
+```text
+my-game/
+├── godot/
+│   ├── addons/godot-bevy/
+│   ├── project.godot
+│   └── .godot/extension_list.cfg
+└── rust/
+    ├── Cargo.toml
+    ├── run_godot.rs
+    └── src/
+        ├── lib.rs
+        └── itests.rs
 ```
 
-A unit test can't verify this works correctly because:
-- `Time` comes from Bevy's runtime
-- `GodotNodeHandle` requires a real Godot node
-- Transform sync needs Godot's scene tree
-- Frame timing depends on Godot's main loop
+Install or symlink the addon into `godot/addons/godot-bevy`, and configure its `BevyAppSingleton` autoload. The generated GDExtension must be imported once so Godot records it in `.godot/extension_list.cfg`.
 
-Integration tests solve this by running your code in the actual Godot environment.
+## Setup
 
-## Setting Up Integration Tests
-
-### 1. Create a Test Crate
-
-Integration tests live in a separate crate that compiles to a GDExtension library:
+Add the optional test dependency and enable the frame signal used by the harness:
 
 ```toml
-# my-game-tests/Cargo.toml
-[package]
-name = "my-game-tests"
-version = "0.1.0"
-edition = "2024"
-
-[lib]
-crate-type = ["cdylib"]
-
-[dependencies]
-godot = "0.4"
-godot-bevy = "0.11"
-godot-bevy-test = "0.11"
-bevy = { version = "0.18", default-features = false }
-
-# Import your game crate to test its systems
-my-game = { path = "../my-game" }
+godot-bevy-test = { version = "0.11", optional = true }
 ```
 
-### 2. Create the Test Entry Point
+```toml
+itest = ["dep:godot-bevy-test", "godot-bevy-test/test-frame-signal"]
+```
+
+Register the runner in the game library. Keep `#[bevy_app] fn build_app` as the only GDExtension entry point.
 
 ```rust
-// my-game-tests/src/lib.rs
-use godot::init::{ExtensionLibrary, gdextension};
-use godot_bevy_test::prelude::*;
-
-// This macro creates the Godot class that runs tests
-godot_bevy_test::declare_test_runner!();
-
-// Include test modules
-mod movement_tests;
-mod combat_tests;
-
-#[gdextension(entry_symbol = my_game_tests)]
-unsafe impl ExtensionLibrary for IntegrationTests {}
+{{#include ../../../examples/platformer-2d/rust/src/lib.rs:itest}}
 ```
 
-### 3. Set Up the Godot Project
+Set up `run_godot.rs` as shown in [Cargo Run Godot](../getting-started/gdenv.md). Its `itest` path starts the runner scene and sets `GODOT_BEVY_ITEST=1` for the child Godot process.
 
-Create a minimal Godot project to run the tests:
+`#[bevy_app]` leaves `build_app` as a normal function, so `TestApp::new(&ctx, build_app)` works. Most tests should add only the plugins they cover.
 
-```
-my-game-tests/
-├── rust/
-│   └── ... (your test crate)
-└── godot/
-    ├── project.godot
-    └── my-game-tests.gdextension
-```
+## Writing tests
 
-Your `.gdextension` file should point to your test library:
-
-```ini
-[configuration]
-entry_symbol = "my_game_tests"
-compatibility_minimum = 4.3
-
-[libraries]
-linux.debug.x86_64 = "res://../target/debug/libmy_game_tests.so"
-macos.debug = "res://../target/debug/libmy_game_tests.dylib"
-windows.debug.x86_64 = "res://../target/debug/my_game_tests.dll"
-```
-
-## Writing Tests
-
-### Basic Async Test
-
-Most tests are async because they need to wait for Godot frames:
+Use `#[itest]` on an async function with an owned `TestContext`. `TestApp` initializes the autoload, waits for the initial scene-tree population, and gives the test explicit frame control.
 
 ```rust
-use godot_bevy_test::prelude::*;
-use bevy::prelude::*;
-
-#[itest(async)]
-fn test_entity_spawns(ctx: &TestContext) -> godot::task::TaskHandle {
-    godot::task::spawn(async move {
-        // Create a test app with your plugins
-        let mut app = TestApp::new(&ctx, |app| {
-            app.add_plugins(MyGamePlugin);
-        }).await;
-
-        // Run one frame to initialize
-        app.update().await;
-
-        // Spawn an entity
-        app.with_world_mut(|world| {
-            world.spawn((Player::default(), Transform::default()));
-        });
-
-        // Run another frame
-        app.update().await;
-
-        // Verify the entity exists
-        let count = app.with_world(|world| {
-            world.query::<&Player>().iter(world).count()
-        });
-        
-        assert_eq!(count, 1, "Player should exist");
-    })
-}
+{{#include ../../../examples/platformer-2d/rust/src/itests.rs:gem_collected}}
 ```
 
-### Using bevy_app_test! for Quick Tests
-
-For simpler tests, the `bevy_app_test!` macro reduces boilerplate:
+Use `with_world` for read-only access. Use `with_world_mut` for mutations and queries, since creating a Bevy query needs mutable world access.
 
 ```rust
-#[itest(async)]
-fn test_system_runs_each_frame(ctx: &TestContext) -> godot::task::TaskHandle {
-    bevy_app_test!(ctx, counter, |app| {
-        #[derive(Resource)]
-        struct FrameCount(Counter);
-        
-        app.insert_resource(FrameCount(counter.clone()));
-        app.add_systems(Update, |count: Res<FrameCount>| {
-            count.0.increment();
-        });
-    }, async {
-        await_frames(5).await;
-        assert!(counter.get() >= 4, "System should run each frame");
-    })
-}
+{{#include ../../../examples/platformer-2d/rust/src/itests.rs:with_world_mut_query}}
 ```
 
-### Skip and Focus
+`#[itest(async)] fn test(ctx: &TestContext) -> godot::task::TaskHandle` remains available when a test returns an explicitly spawned task. Async functions use an owned context, because a reference cannot outlive the spawned task.
 
-During development, you can skip or focus tests:
+## Running tests
 
-```rust
-#[itest(skip)]              // Skip this test
-fn test_not_ready_yet(ctx: &TestContext) {
-    // Work in progress
-}
-
-#[itest(focus)]             // Only run focused tests
-fn test_debugging_this(ctx: &TestContext) {
-    // When any test has focus, only focused tests run
-}
-
-#[itest(async, skip)]       // Combine attributes
-fn test_flaky(ctx: &TestContext) -> godot::task::TaskHandle {
-    // ...
-}
-```
-
-## Running Tests
-
-Build and run tests in headless mode:
+Run the game crate's runner:
 
 ```bash
-cd my-game-tests
-
-# Build the test library
-cargo build
-
-# Run tests (adjust path to your Godot binary)
-godot4 --headless --path godot --quit-after 5000
+cargo run --features itest
 ```
 
-You'll see output like:
-
-```
-Run godot-bevy async integration tests...
-  Found 5 async tests in 2 files.
-  test_entity_spawns ... ok
-  test_transform_syncs ... ok
-  test_system_runs_each_frame ... ok
-  test_not_ready_yet ... [SKIP]
-  test_player_movement ... ok
-
-Test result:
-  4 passed, 1 skipped in 0.42s
-All tests passed!
-```
-
-### Test Script
-
-Create a shell script for convenience:
+After adding or changing the extension, import the project once. Then a direct invocation is:
 
 ```bash
-#!/bin/bash
-# run-tests.sh
-set -e
-
-cd "$(dirname "$0")"
-cargo build
-
-# Cross-platform temp file for exit code
-EXIT_FILE="${TMPDIR:-/tmp}/godot_test_exit_code"
-rm -f "$EXIT_FILE"
-export GODOT_TEST_EXIT_CODE_PATH="$EXIT_FILE"
-
-godot4 --headless --path godot --quit-after 5000
-
-if [ -f "$EXIT_FILE" ]; then
-    exit $(cat "$EXIT_FILE")
-else
-    exit 1
-fi
+godot --headless --path godot --import
+GODOT_BEVY_ITEST=1 godot --headless --fixed-fps 60 --path godot --scene res://addons/godot-bevy/test/TestRunner.tscn --quit-after 10000
 ```
+
+`ITEST_FILTER` selects comma-separated, case-sensitive name substrings. `ITEST_REPEAT` repeats selected tests. `ITEST_JSON_PATH` writes a report. `#[itest(skip)]` reports a skipped test, while `#[itest(focus)]` selects focused tests; set `ITEST_DENY_FOCUS=1` in CI to reject focus mode. The full configuration table is in the [godot-bevy-test README](https://github.com/bytemeadow/godot-bevy/tree/main/godot-bevy-test#runner-configuration).
+
+## Troubleshooting
+
+### BevyApp defined multiple times
+
+The game and test dependencies resolved different copies of `godot-bevy`. Run `cargo tree -d`, then align their sources and versions. A second test crate that links the game as an rlib is unsupported because it creates duplicate GDExtension entry symbols.
+
+### IntegrationTests class not found
+
+Godot did not load the extension. Run `--import` once and check that `.godot/extension_list.cfg` lists the generated GDExtension.
+
+### Must be run in headless mode
+
+The test runner only runs headlessly. Pass `--headless` when starting Godot.
+
+### Game code runs before the first test
+
+Without `GODOT_BEVY_ITEST`, the game autoload boots for a frame or two before the runner. Its startup logs and any nodes it adds under root appear before `Run godot-bevy integration tests` and leak into every test's scene scan. Set `GODOT_BEVY_ITEST=1` in the process that launches Godot.
 
 ## Benchmarks
 
-The framework also supports benchmarks:
+`#[bench]` runs a function repeatedly and requires a return value so its work is not optimized away:
 
 ```rust
-use godot_bevy_test::bench;
-
 #[bench]
-fn benchmark_spawning() -> i32 {
-    // Code to benchmark - must return a value to prevent optimization
-    let mut count = 0;
-    for _ in 0..1000 {
-        count += 1;
-    }
-    count
+fn name() -> i32 {
+    42
 }
 
-#[bench(repeat = 50)]       // Custom iteration count
-fn benchmark_expensive_op() -> i32 {
-    expensive_operation();
+#[bench(repeat = 50)]
+fn repeated_name() -> i32 {
     42
 }
 ```
 
-Run benchmarks with a separate runner:
+Build the Rust crate with `--release`, then launch the benchmark runner:
 
 ```bash
-godot4 --headless --path godot -s addons/godot-bevy/test/BenchRunner.tscn --quit-after 30000
-```
-
-## Best Practices
-
-### 1. Test Real Behavior
-
-Don't mock Godot - use real nodes and scene tree:
-
-```rust
-// Good: Real Godot node
-let mut node = Node2D::new_alloc();
-ctx.scene_tree.clone().add_child(&node);
-
-// Bad: Trying to fake it
-// let fake_handle = GodotNodeHandle::fake(); // Don't do this
-```
-
-### 2. Clean Up After Tests
-
-Always clean up nodes you create:
-
-```rust
-#[itest(async)]
-fn test_with_cleanup(ctx: &TestContext) -> godot::task::TaskHandle {
-    godot::task::spawn(async move {
-        let mut node = Node2D::new_alloc();
-        ctx.scene_tree.clone().add_child(&node);
-
-        let mut app = TestApp::new(&ctx, |_| {}).await;
-        
-        // ... test code ...
-
-        // Clean up: BevyApp first, then nodes
-        app.cleanup();
-        node.queue_free();
-        await_frame().await;
-    })
-}
-```
-
-### 3. Wait for Frame Processing
-
-Operations often need a frame to complete:
-
-```rust
-// Spawn entity
-app.with_world_mut(|world| { world.spawn(MyComponent); });
-
-// Wait for systems to process
-app.update().await;
-
-// Now query the result
-```
-
-### 4. Use TestApp::cleanup() Before Freeing Nodes
-
-If your test creates Godot nodes that are tracked by Bevy, clean up the BevyApp first:
-
-```rust
-// Wrong order: may crash
-node.queue_free();
-app.cleanup();  // Transform sync might access freed node!
-
-// Correct order
-app.cleanup();  // Stop Bevy systems first
-node.queue_free();
+godot --headless --path godot --scene res://addons/godot-bevy/test/BenchRunner.tscn --quit-after 30000
 ```

--- a/book/src/testing/index.md
+++ b/book/src/testing/index.md
@@ -75,6 +75,8 @@ godot --headless --path godot --import
 GODOT_BEVY_ITEST=1 godot --headless --fixed-fps 60 --path godot --scene res://addons/godot-bevy/test/TestRunner.tscn --quit-after 10000
 ```
 
+Godot can crash on exit after a headless import once a GDExtension is loaded ([godot#111645](https://github.com/godotengine/godot/issues/111645)). The `.godot` folder is written before that, so the crash is harmless and the runner skips the import on later runs.
+
 `ITEST_FILTER` selects comma-separated, case-sensitive name substrings. `ITEST_REPEAT` repeats selected tests. `ITEST_JSON_PATH` writes a report. `#[itest(skip)]` reports a skipped test, while `#[itest(focus)]` selects focused tests; set `ITEST_DENY_FOCUS=1` in CI to reject focus mode. The full configuration table is in the [godot-bevy-test README](https://github.com/bytemeadow/godot-bevy/tree/main/godot-bevy-test#runner-configuration).
 
 ## Troubleshooting

--- a/examples/platformer-2d/rust/Cargo.toml
+++ b/examples/platformer-2d/rust/Cargo.toml
@@ -16,7 +16,8 @@ bevy_asset_loader = "0.27"
 fastrand = { version = "2.3.0" }
 godot = "0.5"
 godot-bevy = { path = "../../../godot-bevy" }
+godot-bevy-test = { path = "../../../godot-bevy-test", optional = true }
 cargo-godot-lib.workspace = true
 
 [features]
-itest = []
+itest = ["dep:godot-bevy-test", "godot-bevy-test/test-frame-signal"]

--- a/examples/platformer-2d/rust/src/itests.rs
+++ b/examples/platformer-2d/rust/src/itests.rs
@@ -1,0 +1,101 @@
+use bevy::prelude::*;
+use godot::classes::Area2D;
+use godot_bevy::prelude::{GodotActionsPlugin, GodotCollisionsPlugin};
+use godot_bevy_test::prelude::*;
+
+use crate::components::{Door, Gem, Player};
+use crate::gameplay::door::DoorPlugin;
+use crate::gameplay::gem::{GemPlugin, GemsCollected};
+use crate::gameplay::player::{PlayerInputMessage, PlayerMovementMessage, PlayerPlugin};
+
+#[itest]
+async fn gem_plugin_starts_empty(ctx: TestContext) {
+    let mut app = TestApp::new(&ctx, |app| {
+        app.add_plugins(GemPlugin);
+    })
+    .await;
+
+    assert_eq!(
+        app.with_world(|world| world.resource::<GemsCollected>().0),
+        0
+    );
+
+    app.cleanup().await;
+}
+
+// ANCHOR: gem_collected
+#[itest]
+async fn gem_collected(ctx: TestContext) {
+    let mut app = TestApp::new(&ctx, |app| {
+        app.add_plugins(GemPlugin);
+    })
+    .await;
+
+    let (_, gem_entity) = app.add_node::<Area2D>("gem").await;
+    let (_, player_entity) = app.add_node::<Area2D>("player").await;
+    app.with_world_mut(|world| {
+        world.entity_mut(gem_entity).insert(Gem);
+        world.entity_mut(player_entity).insert(Player);
+        world.trigger(godot_bevy::prelude::CollisionStarted {
+            entity1: gem_entity,
+            entity2: player_entity,
+        });
+    });
+
+    app.update().await;
+
+    app.with_world(|world| {
+        assert_eq!(world.resource::<GemsCollected>().0, 1);
+        assert!(!world.entities().contains(gem_entity));
+    });
+
+    app.cleanup().await;
+}
+// ANCHOR_END: gem_collected
+
+#[itest]
+async fn player_plugin_registers_messages(ctx: TestContext) {
+    let mut app = TestApp::new(&ctx, |app| {
+        app.add_plugins((GodotActionsPlugin, PlayerPlugin));
+    })
+    .await;
+
+    app.with_world(|world| {
+        assert!(world.contains_resource::<Messages<PlayerInputMessage>>());
+        assert!(world.contains_resource::<Messages<PlayerMovementMessage>>());
+    });
+
+    app.cleanup().await;
+}
+
+// ANCHOR: with_world_mut_query
+#[itest]
+async fn game_components_keep_their_defaults(ctx: TestContext) {
+    let mut app = TestApp::new(&ctx, |app| {
+        app.add_plugins((GodotCollisionsPlugin, DoorPlugin));
+    })
+    .await;
+
+    app.with_world_mut(|world| {
+        world.spawn((Gem, Door::default(), Player));
+
+        let mut doors = world.query::<&Door>();
+        assert_eq!(doors.iter(world).count(), 1);
+    });
+
+    app.update().await;
+    app.cleanup().await;
+}
+// ANCHOR_END: with_world_mut_query
+
+#[itest]
+async fn whole_app_boots(ctx: TestContext) {
+    let mut app = TestApp::new(&ctx, crate::build_app).await;
+
+    app.with_world(|world| {
+        assert!(world.contains_resource::<State<crate::GameState>>());
+        assert_eq!(world.resource::<GemsCollected>().0, 0);
+    });
+
+    app.cleanup().await;
+}

--- a/examples/platformer-2d/rust/src/lib.rs
+++ b/examples/platformer-2d/rust/src/lib.rs
@@ -9,6 +9,14 @@ mod level_manager;
 mod main_menu;
 mod scene_management;
 
+// ANCHOR: itest
+#[cfg(feature = "itest")]
+mod itests;
+
+#[cfg(feature = "itest")]
+godot_bevy_test::declare_test_runner!();
+// ANCHOR_END: itest
+
 #[bevy_app]
 fn build_app(app: &mut App) {
     // This example uses most godot-bevy features

--- a/examples/run_godot.rs
+++ b/examples/run_godot.rs
@@ -41,9 +41,13 @@ fn main() {
         "10000",
     ]);
 
+    // Discard a leftover result from an earlier crashed run.
+    godot_bevy_test::exit_code::read_and_cleanup_exit_code();
+
+    // Godot can die on a signal at shutdown with a GDExtension loaded, after the tests
+    // have already written their result, so the exit file is authoritative.
     if let Err(e) = runner.execute() {
         eprintln!("{e}");
-        std::process::exit(1);
     }
 
     std::process::exit(godot_bevy_test::exit_code::read_and_cleanup_exit_code().unwrap_or(1));

--- a/examples/run_godot.rs
+++ b/examples/run_godot.rs
@@ -12,14 +12,17 @@ fn main() {
 
 #[cfg(feature = "itest")]
 fn main() {
+    unsafe { std::env::set_var("GODOT_BEVY_ITEST", "1") };
+
     let runner = cargo_godot_lib::GodotRunner::create(
         env!("CARGO_PKG_NAME"),
         &std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../godot"),
     );
 
-    #[cfg(feature = "itest")]
     let runner = runner.godot_cli_arguments(vec![
         "--headless",
+        "--fixed-fps",
+        "60",
         "--scene",
         "res://addons/godot-bevy/test/TestRunner.tscn",
         "--quit-after",

--- a/examples/run_godot.rs
+++ b/examples/run_godot.rs
@@ -14,10 +14,22 @@ fn main() {
 fn main() {
     unsafe { std::env::set_var("GODOT_BEVY_ITEST", "1") };
 
+    // Godot always loads the `.debug` entry, so point both entries at the profile
+    // this binary was built with; otherwise `cargo run --release` loads nothing.
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
     let runner = cargo_godot_lib::GodotRunner::create(
         env!("CARGO_PKG_NAME"),
         &std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../godot"),
-    );
+    )
+    .gdextension_config(move |config| {
+        config
+            .debug_target(Some(profile.to_string()))
+            .release_target(Some(profile.to_string()))
+    });
 
     let runner = runner.godot_cli_arguments(vec![
         "--headless",

--- a/godot-bevy-test-macros/src/lib.rs
+++ b/godot-bevy-test-macros/src/lib.rs
@@ -54,7 +54,7 @@ impl Parse for ITestOptions {
 /// ```ignore
 /// #[itest]
 /// async fn my_test(ctx: TestContext) {
-///     let mut app = TestApp::new(&ctx, |_| {}).await;
+///     let app = TestApp::new(&ctx, |_| {}).await;
 ///     app.update().await;
 /// }
 ///

--- a/godot-bevy-test-macros/src/lib.rs
+++ b/godot-bevy-test-macros/src/lib.rs
@@ -2,7 +2,9 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::ext::IdentExt;
 use syn::parse::{Parse, ParseStream};
-use syn::{Ident, ItemFn, Lit, Meta, MetaNameValue, ReturnType, Token, parse_macro_input};
+use syn::{
+    FnArg, Ident, ItemFn, Lit, Meta, MetaNameValue, ReturnType, Token, Type, parse_macro_input,
+};
 
 #[derive(Default)]
 struct ITestOptions {
@@ -45,13 +47,15 @@ impl Parse for ITestOptions {
     }
 }
 
-/// Attribute macro for integration tests
+/// Attribute macro for integration tests.
 ///
 /// Usage:
 /// <!-- qualification-doctest: scaffold=book-tests/src/doctest_scaffolds.rs#itest -->
 /// ```ignore
 /// #[itest]
-/// fn my_sync_test(ctx: &TestContext) {
+/// async fn my_test(ctx: TestContext) {
+///     let mut app = TestApp::new(&ctx, |_| {}).await;
+///     app.update().await;
 /// }
 ///
 /// #[itest(async)]
@@ -78,10 +82,25 @@ impl Parse for ITestOptions {
 /// #[itest(foucs)]
 /// fn misspelled_option() {}
 /// ```
+///
+/// Async functions take `TestContext` by value. References cannot outlive the
+/// wrapper that starts the task:
+/// ```compile_fail
+/// use godot_bevy_test_macros::itest;
+///
+/// struct TestContext;
+///
+/// #[itest]
+/// async fn borrowed_context(_ctx: &TestContext) {}
+/// ```
 #[proc_macro_attribute]
 pub fn itest(attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemFn);
     let options = parse_macro_input!(attr as ITestOptions);
+    expand_itest(input, options).into()
+}
+
+fn expand_itest(input: ItemFn, options: ITestOptions) -> proc_macro2::TokenStream {
     let is_async = options.is_async;
     let is_skipped = options.is_skipped;
     let is_focused = options.is_focused;
@@ -98,13 +117,73 @@ pub fn itest(attr: TokenStream, item: TokenStream) -> TokenStream {
         quote! { _ctx: &::godot_bevy_test::TestContext }
     };
 
-    if is_async {
+    if input.sig.asyncness.is_some() {
+        if !matches!(input.sig.output, ReturnType::Default) {
+            return syn::Error::new_spanned(
+                &input.sig.output,
+                "async #[itest] functions must return ()",
+            )
+            .into_compile_error();
+        }
+
+        if input.sig.inputs.len() > 1 {
+            return syn::Error::new_spanned(
+                &input.sig.inputs,
+                "async #[itest] functions accept at most one TestContext parameter",
+            )
+            .into_compile_error();
+        }
+
+        let (wrapper_param, context) = match input.sig.inputs.first() {
+            Some(FnArg::Typed(param)) => {
+                if matches!(&*param.ty, Type::Reference(_)) {
+                    return syn::Error::new_spanned(
+                        &param.ty,
+                        "async #[itest] functions must take TestContext by value",
+                    )
+                    .into_compile_error();
+                }
+                let pattern = &param.pat;
+                (
+                    quote! { ctx: &::godot_bevy_test::TestContext },
+                    quote! { let #pattern = ctx.clone(); },
+                )
+            }
+            Some(FnArg::Receiver(receiver)) => {
+                return syn::Error::new_spanned(
+                    receiver,
+                    "async #[itest] functions accept TestContext by value",
+                )
+                .into_compile_error();
+            }
+            None => (quote! { _ctx: &::godot_bevy_test::TestContext }, quote! {}),
+        };
+
+        quote! {
+            #visibility fn #test_name(#wrapper_param) -> ::godot::task::TaskHandle {
+                #context
+                ::godot::task::spawn(async move #body)
+            }
+
+            ::godot::sys::shard_add!(
+                ::godot_bevy_test::__GODOT_ASYNC_ITEST;
+                ::godot_bevy_test::AsyncRustTestCase {
+                    name: #test_name_str,
+                    file: file!(),
+                    skipped: #is_skipped,
+                    focused: #is_focused,
+                    line: line!(),
+                    function: #test_name,
+                }
+            );
+        }
+    } else if is_async {
         let return_ty = match &input.sig.output {
             ReturnType::Type(_, ty) => quote! { -> #ty },
             ReturnType::Default => quote! { -> ::godot::task::TaskHandle },
         };
 
-        TokenStream::from(quote! {
+        quote! {
             #visibility fn #test_name(#param) #return_ty {
                 #body
             }
@@ -120,9 +199,9 @@ pub fn itest(attr: TokenStream, item: TokenStream) -> TokenStream {
                     function: #test_name,
                 }
             );
-        })
+        }
     } else {
-        TokenStream::from(quote! {
+        quote! {
             #visibility fn #test_name(#param) {
                 #body
             }
@@ -138,7 +217,7 @@ pub fn itest(attr: TokenStream, item: TokenStream) -> TokenStream {
                     function: #test_name,
                 }
             );
-        })
+        }
     }
 }
 

--- a/godot-bevy-test-macros/src/lib.rs
+++ b/godot-bevy-test-macros/src/lib.rs
@@ -144,9 +144,10 @@ fn expand_itest(input: ItemFn, options: ITestOptions) -> proc_macro2::TokenStrea
                     .into_compile_error();
                 }
                 let pattern = &param.pat;
+                let ty = &param.ty;
                 (
                     quote! { ctx: &::godot_bevy_test::TestContext },
-                    quote! { let #pattern = ctx.clone(); },
+                    quote! { let #pattern: #ty = ctx.clone(); },
                 )
             }
             Some(FnArg::Receiver(receiver)) => {

--- a/godot-bevy-test-macros/src/lib_tests.rs
+++ b/godot-bevy-test-macros/src/lib_tests.rs
@@ -31,6 +31,14 @@ mod tests {
     }
 
     #[test]
+    fn async_function_keeps_the_declared_parameter_type() {
+        let input = syn::parse2(quote! { async fn test_name(ctx: TestContext) {} }).unwrap();
+        let expanded = expand_itest(input, ITestOptions::default()).to_string();
+
+        assert!(expanded.contains("let ctx : TestContext = ctx . clone ()"));
+    }
+
+    #[test]
     fn async_function_rejects_borrowed_context() {
         let input = syn::parse2(quote! { async fn test_name(ctx: &TestContext) {} }).unwrap();
         let expanded = expand_itest(input, ITestOptions::default());

--- a/godot-bevy-test-macros/src/lib_tests.rs
+++ b/godot-bevy-test-macros/src/lib_tests.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
     use super::*;
+    use quote::quote;
 
     #[test]
     fn parses_exact_itest_options() {
@@ -14,5 +15,38 @@ mod tests {
     fn rejects_unknown_and_duplicate_itest_options() {
         assert!(syn::parse_str::<ITestOptions>("asyncish").is_err());
         assert!(syn::parse_str::<ITestOptions>("focus, focus").is_err());
+    }
+
+    #[test]
+    fn async_function_registers_an_async_test_case() {
+        let input = syn::parse2(quote! {
+            async fn test_name(ctx: TestContext) {
+                let _ = ctx;
+            }
+        })
+        .unwrap();
+        let expanded = expand_itest(input, ITestOptions::default());
+
+        assert!(expanded.to_string().contains("AsyncRustTestCase"));
+    }
+
+    #[test]
+    fn async_function_rejects_borrowed_context() {
+        let input = syn::parse2(quote! { async fn test_name(ctx: &TestContext) {} }).unwrap();
+        let expanded = expand_itest(input, ITestOptions::default());
+
+        assert!(expanded
+            .to_string()
+            .contains("must take TestContext by value"));
+    }
+
+    #[test]
+    fn async_function_rejects_non_unit_return() {
+        let input = syn::parse2(quote! { async fn test_name() -> bool { true } }).unwrap();
+        let expanded = expand_itest(input, ITestOptions::default());
+
+        assert!(expanded
+            .to_string()
+            .contains("async #[itest] functions must return ()"));
     }
 }

--- a/godot-bevy-test/README.md
+++ b/godot-bevy-test/README.md
@@ -1,155 +1,80 @@
 # godot-bevy-test
 
-Integration testing framework for godot-bevy projects.
+`godot-bevy-test` runs integration tests inside Godot with real frame progression.
 
-This crate provides a testing framework for writing integration tests that run inside Godot with full access to both Bevy ECS and Godot's runtime. Tests execute in headless mode with real frame progression, allowing you to verify your game logic works correctly in the actual runtime environment.
+## Setup
 
-## Features
-
-- **Real Godot Integration**: Tests run in Godot's headless mode with actual frame progression
-- **Async Test Support**: Wait for frames, test across multiple update cycles
-- **Bevy-style API**: Familiar `TestApp` pattern with world access
-- **Structured Reports**: Versioned JSON with per-attempt timing and failures
-- **Filtering & Repeats**: Select by name, repeat tests, and detect flakes
-- **Benchmark Support**: Performance benchmarking with statistical analysis
-- **Focus & Skip**: Easily focus on specific tests or skip work-in-progress
-- **Cross-platform**: Works on Linux, macOS, and Windows
-
-## Quick Start
-
-### 1. Create a Test Crate
-
-Create a separate crate for your integration tests:
+Keep tests in the game crate and gate them behind an `itest` feature. The game keeps its existing `cdylib` and `#[bevy_app]` entry point.
 
 ```toml
-# my-game-tests/Cargo.toml
-[package]
-name = "my-game-tests"
-version = "0.1.0"
-edition = "2024"
-
-[lib]
-crate-type = ["cdylib"]
-
 [dependencies]
+bevy = { version = "0.19", default-features = false }
 godot = "0.5"
 godot-bevy = "0.11"
-godot-bevy-test = "0.11"
-bevy = { version = "0.18", default-features = false }
+godot-bevy-test = { version = "0.11", optional = true }
 
-# Your game crate (for testing your components/systems)
-my-game = { path = "../my-game" }
+[features]
+itest = ["dep:godot-bevy-test", "godot-bevy-test/test-frame-signal"]
 ```
 
-### 2. Set Up the Test Entry Point
+Register the runner in the same library as the game extension:
 
 ```rust
-// my-game-tests/src/lib.rs
-use godot::init::{ExtensionLibrary, gdextension};
-use godot_bevy_test::prelude::*;
+#[cfg(feature = "itest")]
+mod itests;
 
-// Declare the test runner class for Godot
+#[cfg(feature = "itest")]
 godot_bevy_test::declare_test_runner!();
-
-// Include your test modules
-mod player_tests;
-mod combat_tests;
-
-#[gdextension(entry_symbol = my_game_tests)]
-unsafe impl ExtensionLibrary for IntegrationTests {}
 ```
 
-### 3. Write Tests
+Use the game’s Godot project. It needs the `godot-bevy` addon and the `BevyAppSingleton` autoload. Launch `res://addons/godot-bevy/test/TestRunner.tscn` with `--scene`; do not copy the runner scene into another project. Set `GODOT_BEVY_ITEST=1` before starting Godot so the autoload does not boot the game before the runner initializes it.
+
+## Writing tests
+
+The usual form is an async function with an owned `TestContext`:
 
 ```rust
-// my-game-tests/src/player_tests.rs
 use bevy::prelude::*;
 use godot_bevy_test::prelude::*;
-use my_game::Player;
 
-#[itest(async)]
-fn test_player_movement(ctx: &TestContext) -> godot::task::TaskHandle {
-    godot::task::spawn(async move {
-        let mut app = TestApp::new(&ctx, |app| {
-            app.add_plugins(my_game::PlayerPlugin);
-        }).await;
-
-        // Spawn a player
-        app.with_world_mut(|world| {
-            world.spawn((Player::default(), Transform::default()));
-        });
-
-        // Run a few frames
-        for _ in 0..5 {
-            app.update().await;
-        }
-
-        // Verify player moved
-        let pos = app.with_world(|world| {
-            world.query::<&Transform>()
-                .iter(world)
-                .next()
-                .unwrap()
-                .translation
-        });
-        
-        assert!(pos.x > 0.0, "Player should have moved");
+#[itest]
+async fn player_spawns(ctx: TestContext) {
+    let mut app = TestApp::new(&ctx, |app| {
+        app.add_plugins(PlayerPlugin);
     })
+    .await;
+
+    app.with_world_mut(|world| {
+        let mut players = world.query::<&Player>();
+        assert_eq!(players.iter(world).count(), 0);
+    });
+
+    app.cleanup().await;
 }
 ```
 
-### 4. Set Up Godot Test Project
+Use `with_world` for read-only access. Queries require `with_world_mut`, because constructing a Bevy query mutates world-local query state.
 
-Create a minimal Godot project for running tests:
+`#[itest(async)] fn test(ctx: &TestContext) -> godot::task::TaskHandle` is still supported when a test must return an explicitly spawned task. Async functions cannot take `&TestContext` because that reference cannot outlive the wrapper.
 
-```
-my-game-tests/
-├── godot/
-│   ├── project.godot
-│   └── my-game-tests.gdextension
-```
+`#[itest(skip)]` leaves a test in the report without running it. `#[itest(focus)]` runs only focused tests. `ITEST_DENY_FOCUS=1` rejects focused registrations in CI.
 
-The `.gdextension` file should point to your test library:
+## Running tests
 
-```ini
-[configuration]
-entry_symbol = "my_game_tests"
-compatibility_minimum = 4.3
-
-[libraries]
-linux.debug.x86_64 = "res://../target/debug/libmy_game_tests.so"
-# ... other platforms
-```
-
-**Important:** The godot-bevy plugin must be enabled (or `BevyAppSingleton` registered as an autoload) in the test project's `project.godot`. `TestApp` uses the autoload to match production node layout.
-
-### 5. Run Tests
+Run the game crate’s runner:
 
 ```bash
-cd my-game-tests
-cargo build
-godot4 --headless --path godot --quit-after 5000
+cargo run --features itest
 ```
 
-## API Reference
+For a direct launch, import once after adding or changing the extension, then run:
 
-### Test Macros
-
-```rust
-#[itest]                    // Sync test
-#[itest(async)]             // Async test (most common)
-#[itest(skip)]              // Skip this test
-#[itest(focus)]             // Only run focused tests
-#[itest(async, skip)]       // Combine attributes
+```bash
+godot --headless --path godot --import
+GODOT_BEVY_ITEST=1 godot --headless --fixed-fps 60 --path godot --scene res://addons/godot-bevy/test/TestRunner.tscn --quit-after 10000
 ```
 
-Macro options are exact tokens. Unknown or misspelled options are compile errors.
-Focus selects only focused registrations and still intersects with `ITEST_FILTER`.
-Set `ITEST_DENY_FOCUS=1` in CI to reject focus mode before tests execute.
-
-### Runner Configuration
-
-The runner reads these environment variables:
+## Runner configuration
 
 | Variable | Meaning |
 | --- | --- |
@@ -160,99 +85,41 @@ The runner reads these environment variables:
 | `ITEST_DENY_FOCUS` | `1`/`true` rejects focused runs; default false |
 | `ITEST_BUILD_PROFILE` | `debug` or `release` report metadata |
 
-Filters are trimmed and empty terms are discarded; a fully empty filter or a
-zero-test selection is a configuration error. Skip affects execution after
-selection, so selected skipped tests remain visible in the report.
+Filters are trimmed and empty terms are discarded. Empty selections are configuration errors. Skip affects execution after selection, so selected skipped tests remain visible in the report.
 
-The report schema is published at
-`schema/itest-report-v1.schema.json`. Requested reports are checkpointed with
-`complete: false` after every logical test and atomically finalized. Exit codes
-are 0 for pass, 1 for failed/flaky/timeout results, and 2 for configuration or
-harness errors.
+## TestApp
 
-### TestApp
+`TestApp::new(&ctx, build_app)` can boot the full game because `#[bevy_app]` leaves `build_app` as a normal function. Prefer adding the specific plugins a test needs. `update().await` advances one frame, and `physics_update().await` guarantees a physics tick. Call `cleanup().await` before freeing Godot nodes used by the test.
 
-The main testing interface:
+## Benchmarks
 
-```rust
-// Create with custom setup
-let mut app = TestApp::new(&ctx, |app| {
-    app.add_plugins(MyPlugin);
-}).await;
-
-// Step one frame
-app.update().await;
-
-// Access the world
-app.with_world(|world| { /* read-only */ });
-app.with_world_mut(|world| { /* read-write */ });
-
-// Convenience methods
-let transform = app.get_single::<Transform>();
-let entity = app.single_entity_with::<Player>();
-
-// Cleanup (automatic on drop, but prefer explicit async cleanup)
-app.cleanup().await;
-```
-
-### Frame Helpers
-
-```rust
-await_frame().await;        // Wait for next frame
-await_frames(5).await;      // Wait for N frames
-```
-
-### bevy_app_test! Macro
-
-For quick test setup with a counter:
-
-```rust
-#[itest(async)]
-fn test_systems_run(ctx: &TestContext) -> godot::task::TaskHandle {
-    bevy_app_test!(ctx, counter, |app| {
-        app.add_systems(Update, move |c: Res<MyCounter>| {
-            counter.increment();
-        });
-    }, async {
-        await_frames(5).await;
-        assert!(counter.get() >= 4);
-    })
-}
-```
-
-### Benchmarks
+`#[bench]` runs a function repeatedly and requires a return value so its work is not optimized away:
 
 ```rust
 #[bench]
-fn my_benchmark() -> i32 {
-    // Code to benchmark - must return a value
-    expensive_operation();
+fn name() -> i32 {
     42
 }
 
-#[bench(repeat = 50)]       // Custom iteration count
-fn expensive_benchmark() -> i32 {
-    very_expensive_operation();
+#[bench(repeat = 50)]
+fn repeated_name() -> i32 {
     42
 }
 ```
 
-## Custom Test Runner Name
+Build the Rust crate with `--release`, then launch:
 
-If you need a custom class name:
-
-```rust
-godot_bevy_test::declare_test_runner!(MyCustomTestRunner);
-
-#[gdextension(entry_symbol = my_tests)]
-unsafe impl ExtensionLibrary for MyCustomTestRunner {}
+```bash
+godot --headless --path godot --scene res://addons/godot-bevy/test/BenchRunner.tscn --quit-after 30000
 ```
 
-Then update `addons/godot-bevy/test/TestRunner.gd`:
+## Troubleshooting
 
-```gdscript
-@export var test_class_name: String = "MyCustomTestRunner"
-```
+`BevyApp` defined multiple times means the game and test dependencies resolved different copies of `godot-bevy`. Run `cargo tree -d` and align their sources and versions. `IntegrationTests class not found` usually means Godot has not imported the extension or `.godot/extension_list.cfg` does not contain it; run the one-time `--import` command. A separate test crate that links the game as an rlib is unsupported because it creates duplicate GDExtension entry symbols.
+
+### Game code runs before the first test
+
+Without `GODOT_BEVY_ITEST`, the game autoload boots for a frame or two before the runner. Its startup logs and any nodes it adds under root appear before `Run godot-bevy integration tests` and leak into every test's scene scan. Set `GODOT_BEVY_ITEST=1` in the process that launches Godot.
 
 ## License
 

--- a/godot-bevy-test/README.md
+++ b/godot-bevy-test/README.md
@@ -74,6 +74,8 @@ godot --headless --path godot --import
 GODOT_BEVY_ITEST=1 godot --headless --fixed-fps 60 --path godot --scene res://addons/godot-bevy/test/TestRunner.tscn --quit-after 10000
 ```
 
+Godot can crash on exit after a headless import once a GDExtension is loaded ([godot#111645](https://github.com/godotengine/godot/issues/111645)). The `.godot` folder is written before that, so the crash is harmless and the runner skips the import on later runs.
+
 ## Runner configuration
 
 | Variable | Meaning |

--- a/godot-bevy-test/src/lib.rs
+++ b/godot-bevy-test/src/lib.rs
@@ -1,56 +1,48 @@
-//! Integration testing framework for godot-bevy projects
+//! Integration tests for godot-bevy projects.
 //!
-//! This crate provides a testing framework for writing integration tests
-//! that run inside Godot with full access to both Bevy ECS and Godot's runtime.
+//! Tests live in the game crate behind an `itest` feature and run in that
+//! crate's Godot project. The runner needs the godot-bevy addon and the
+//! `BevyAppSingleton` autoload already used by the game.
 //!
 //! # Quick Start
 //!
-//! 1. Add dependencies to your test crate's `Cargo.toml`:
+//! Add the optional dependency and feature to the game crate's `Cargo.toml`:
 //! ```toml
-//! [package]
-//! name = "my-game-tests"
-//! edition = "2024"
-//!
-//! [lib]
-//! crate-type = ["cdylib"]
-//!
 //! [dependencies]
-//! godot = "0.4"
-//! godot-bevy = "0.9"
-//! godot-bevy-test = "0.9"
+//! godot = "0.5"
+//! godot-bevy = "0.11"
+//! godot-bevy-test = { version = "0.11", optional = true }
+//! bevy = { version = "0.19", default-features = false }
+//!
+//! [features]
+//! itest = ["dep:godot-bevy-test", "godot-bevy-test/test-frame-signal"]
 //! ```
 //!
-//! 2. Set up your test entry point in `src/lib.rs`:
+//! Register the test runner alongside the normal `#[bevy_app]` entry point:
 //! ```no_run
-//! use godot::init::{ExtensionLibrary, gdextension};
-//! use godot_bevy_test::prelude::*;
-//!
+//! #[cfg(feature = "itest")]
 //! godot_bevy_test::declare_test_runner!();
 //!
-//! mod my_tests {}
-//!
-//! #[gdextension(entry_symbol = my_game_tests)]
-//! unsafe impl ExtensionLibrary for IntegrationTests {}
+//! #[cfg(feature = "itest")]
+//! mod itests;
 //! # fn main() {}
 //! ```
 //!
-//! 3. Write tests using the `#[itest]` macro:
+//! Write asynchronous tests with an owned [`TestContext`]:
 //! ```no_run
 //! use godot_bevy_test::prelude::*;
 //!
-//! #[itest(async)]
-//! fn test_player_spawns(ctx: &TestContext) -> godot::task::TaskHandle {
-//!     let ctx = ctx.clone();
-//!     godot::task::spawn(async move {
-//!         let mut app = TestApp::new(&ctx, |_app| {}).await;
-//!
-//!         app.update().await;
-//!     })
+//! #[itest]
+//! async fn test_player_spawns(ctx: TestContext) {
+//!     let mut app = TestApp::new(&ctx, |_app| {}).await;
+//!     app.update().await;
+//!     app.cleanup().await;
 //! }
 //! # fn main() {}
 //! ```
 //!
-//! 4. Set up a Godot project with `TestRunner.gd` and run tests headlessly.
+//! The explicit alternative is `#[itest(async)] fn test(ctx: &TestContext) ->
+//! godot::task::TaskHandle`, returning `godot::task::spawn(async move { ... })`.
 
 pub mod bencher;
 mod config;
@@ -98,7 +90,7 @@ pub mod prelude {
 /// Macro to declare the test runner GodotClass in user's crate
 ///
 /// This creates the `IntegrationTests` class (or custom name) that Godot will instantiate.
-/// Must be called once in your test crate's lib.rs.
+/// Must be called once in your game crate's lib.rs.
 ///
 /// # Example
 /// ```no_run

--- a/godot-bevy/src/app.rs
+++ b/godot-bevy/src/app.rs
@@ -103,6 +103,10 @@ fn log_plugin_diagnostics(app: &App) {
     );
 }
 
+/// Godot node hosting the Bevy `App`; the `BevyAppSingleton` autoload is one of these.
+///
+/// Integration-test runs set `GODOT_BEVY_ITEST` so the autoload does not boot the
+/// `#[bevy_app]` function; `TestApp` initializes it per test instead.
 #[derive(GodotClass)]
 #[class(base=Node)]
 pub struct BevyApp {
@@ -455,6 +459,12 @@ impl INode for BevyApp {
         // Registered before the init check so it exists without a full Bevy app.
         #[cfg(debug_assertions)]
         self.register_optimized_bulk_operations();
+
+        // Integration-test runs set this so the autoload stays inert until TestApp initializes it;
+        // the runner scene loads after the autoload and cannot stop it otherwise.
+        if std::env::var_os("GODOT_BEVY_ITEST").is_some() {
+            return;
+        }
 
         let has_init = self.instance_init_func.is_some() || BEVY_INIT_FUNC.get().is_some();
         if !has_init {

--- a/godot-bevy/src/app.rs
+++ b/godot-bevy/src/app.rs
@@ -460,8 +460,6 @@ impl INode for BevyApp {
         #[cfg(debug_assertions)]
         self.register_optimized_bulk_operations();
 
-        // Integration-test runs set this so the autoload stays inert until TestApp initializes it;
-        // the runner scene loads after the autoload and cannot stop it otherwise.
         if std::env::var_os("GODOT_BEVY_ITEST").is_some() {
             return;
         }

--- a/godot-bevy/src/plugins/godot_bevy_logger.rs
+++ b/godot-bevy/src/plugins/godot_bevy_logger.rs
@@ -76,18 +76,20 @@ impl Plugin for GodotBevyLogPlugin {
             timestamp_format: self.timestamp_format.clone(),
         };
 
+        // A second app in the same process (itest re-initialization) finds the first one's
+        // subscriber already installed; keep it rather than panic.
         #[cfg(feature = "trace_tracy")]
-        tracing_subscriber::registry()
+        let _ = tracing_subscriber::registry()
             .with(godot_proxy_layer)
             .with(filter_layer)
             .with(tracing_tracy::TracyLayer::default())
-            .init();
+            .try_init();
 
         #[cfg(not(feature = "trace_tracy"))]
-        tracing_subscriber::registry()
+        let _ = tracing_subscriber::registry()
             .with(godot_proxy_layer)
             .with(filter_layer)
-            .init();
+            .try_init();
     }
 }
 

--- a/itest/qualification/doctests-v1.toml
+++ b/itest/qualification/doctests-v1.toml
@@ -1,6 +1,6 @@
 version = 1
 scaffold_path = "book-tests/src/doctest_scaffolds.rs"
-scaffold_sha256 = "sha256:bfd638c61e3d3b5bbc7439ef5b826dcc7eae413f890e10804f96820e3a2abab0"
+scaffold_sha256 = "sha256:436eb10098fd9caacbd707be7544a873259175fd82cfd57b8e6cb5b1519481bc"
 
 [[fences]]
 source = "godot-bevy-macros/src/lib.rs"
@@ -69,7 +69,7 @@ scaffold = "book-tests/src/doctest_scaffolds.rs#godot_node_fields"
 source = "godot-bevy-test-macros/src/lib.rs"
 ordinal = 1
 category = "compiled_scaffold"
-fingerprint = "sha256:ef26aae70578cfc76d53cc83e46157bff02515b3b359c16a84b493919b112d05"
+fingerprint = "sha256:3d9ab6704874945b565e04e57da06d134646de6536c458ad972c4cad4fed035d"
 scaffold = "book-tests/src/doctest_scaffolds.rs#itest"
 
 [[fences]]
@@ -83,14 +83,14 @@ scaffold = "book-tests/src/doctest_scaffolds.rs#bench"
 source = "godot-bevy-test/src/lib.rs"
 ordinal = 1
 category = "compiled_no_run"
-fingerprint = "sha256:c8722d53eb716e72ef415a00ae73ec70042268828e5357f0797e01ac06d6b279"
+fingerprint = "sha256:256ff0119cd6b87af2a4c26f1ab096534b1ee25421394573bc37a82eac22d2d3"
 scaffold = ""
 
 [[fences]]
 source = "godot-bevy-test/src/lib.rs"
 ordinal = 2
 category = "compiled_no_run"
-fingerprint = "sha256:41267677e233df039e68ef4155ddfe895b5c717ce6215a0bde5349e0526aaf65"
+fingerprint = "sha256:87621048bfcc6cb2e35f7aae809421fd784155f8917ce64515393ac82e4f7fdd"
 scaffold = ""
 
 [[fences]]

--- a/itest/qualification/doctests-v1.toml
+++ b/itest/qualification/doctests-v1.toml
@@ -1,6 +1,6 @@
 version = 1
 scaffold_path = "book-tests/src/doctest_scaffolds.rs"
-scaffold_sha256 = "sha256:436eb10098fd9caacbd707be7544a873259175fd82cfd57b8e6cb5b1519481bc"
+scaffold_sha256 = "sha256:7b08b83241e5236127c5ca9bc8f2bb91586532e006d2701fd90e4017593b58c2"
 
 [[fences]]
 source = "godot-bevy-macros/src/lib.rs"
@@ -69,7 +69,7 @@ scaffold = "book-tests/src/doctest_scaffolds.rs#godot_node_fields"
 source = "godot-bevy-test-macros/src/lib.rs"
 ordinal = 1
 category = "compiled_scaffold"
-fingerprint = "sha256:3d9ab6704874945b565e04e57da06d134646de6536c458ad972c4cad4fed035d"
+fingerprint = "sha256:3f75cf74b739b657ac288261b040ca11d552b9230562cd86012da43ffd59395f"
 scaffold = "book-tests/src/doctest_scaffolds.rs#itest"
 
 [[fences]]


### PR DESCRIPTION
Folks kept getting stuck wiring `godot-bevy-test` into their own game (Reece on discord, and I hit it myself). The book told you to make a second crate plus a second godot project, and that's exactly where it breaks: the game crate has to become an rlib, `#[bevy_app]`'s gdextension entry gets linked into the test lib (duplicate symbol on linux), and if the two godot-bevy deps resolve to different sources you get `BevyApp` registered twice at startup. On top of that the example on the page didn't compile and documented a `bevy_app_test!` macro that doesn't exist.

This makes the single-crate path the documented one, which the gdenv page already half described:

- tests live in the game crate behind an `itest` feature and run against the game's own godot project via `--scene res://addons/godot-bevy/test/TestRunner.tscn`
- `GODOT_BEVY_ITEST` keeps the autoload from booting the game before the runner takes over; `run_godot.rs` sets it
- `#[itest] async fn test(ctx: TestContext)` works now, no more `TaskHandle` + `ctx.clone()` dance (the old form still compiles)
- `GodotBevyLogPlugin` uses `try_init`, so booting the whole app twice in one process (i.e. in a test) no longer panics
- platformer-2d gets real integration tests, the book includes its snippets from there, and CI runs them next to itest

Book page rewritten around this with a troubleshooting section for the failure modes above.
