### PR TITLE
Don't free nodes that leave the tree without being destroyed

### DIFF
--- a/book/src/scene-tree/excluding-nodes.md
+++ b/book/src/scene-tree/excluding-nodes.md
@@ -1,8 +1,9 @@
 # Excluding Nodes
 
-By default every Godot node becomes a Bevy entity. To keep a node -- and everything
-under it -- out of the ECS, give it the `_bevy_exclude` metadata. Excluded nodes never
-cross into Bevy: the GDScript watcher filters them out before they reach Rust.
+By default every Godot node becomes a Bevy entity. To keep a node and its descendants
+out of the ECS, give it the `_bevy_exclude` metadata. The GDScript watcher filters
+excluded additions before they reach Rust. Removal messages still reach Bevy so
+entities can be cleaned up when mirrored nodes move into excluded subtrees.
 
 The typical use is a UI or editor-only subtree you never query from ECS. Set the metadata
 in the editor (select the node, **Inspector > Add Metadata**, name it `_bevy_exclude`,
@@ -41,7 +42,11 @@ instead.
 
 ## Timing
 
-Exclusion is decided once, when the node is added. Adding or removing the metadata at
-runtime does not retroactively mirror or unmirror a node. The one exception:
-**reparenting an already-mirrored node into an excluded subtree tears its entity down**,
-so a node that moves out of the ECS does not linger with a stale parent.
+Exclusion is decided when the node is added. Adding or removing the metadata at
+runtime does not retroactively mirror or unmirror a node. Reparenting a mirrored
+node into an excluded subtree removes its ordinary mirror entity while preserving
+the Godot node and its descendants. `ProtectedNodeEntity` entities keep their gameplay
+components but lose their Godot handles, index entries, and scene-tree relationships.
+The caller remains responsible for the surviving nodes. Moving them back into the
+mirrored tree after cleanup creates fresh entities unless handles were explicitly
+reassociated with protected survivors before re-entry.

--- a/book/src/scene-tree/timing.md
+++ b/book/src/scene-tree/timing.md
@@ -34,6 +34,17 @@ After the initial parse, the library continues to listen for scene tree changes 
 
 This separation allows other systems to also react to `SceneTreeEvent`s if needed.
 
+Detaching a node with `remove_child()` preserves the node and its descendants. Once
+removal messages are processed, ordinary mirror entities are despawned.
+`ProtectedNodeEntity` entities keep their gameplay components but lose their Godot
+handles, index entries, and scene-tree relationships. The caller must eventually
+reattach or free detached nodes. Reattaching after cleanup creates fresh entities;
+it does not restore their former ECS state or reconnect protected survivors. To
+reuse a protected entity, attach its `GodotNodeHandle` before re-entry. A reparent
+completed within the mirrored tree before removal processing preserves the entity
+and its state. Explicit ECS despawn and explicit `GodotNodeHandle` removal still
+queue the node for deletion, including while detachment awaits processing.
+
 ## What Components Are Available?
 
 When the scene tree is parsed, each Godot node becomes a Bevy entity with these components:

--- a/godot-bevy/src/plugins/core.rs
+++ b/godot-bevy/src/plugins/core.rs
@@ -4,6 +4,7 @@ use bevy_ecs::event::EntityEvent;
 use bevy_ecs::lifecycle::Remove;
 use bevy_ecs::observer::On;
 use bevy_ecs::prelude::{Name, Resource};
+use bevy_ecs::query::Without;
 use bevy_ecs::schedule::IntoScheduleConfigs;
 use bevy_ecs::system::{Query, ResMut};
 use bevy_time::{Time, Virtual};
@@ -172,9 +173,13 @@ where
     }
 }
 
+// Mirror cleanup must not turn a Godot tree departure into node deletion.
+#[derive(Component)]
+pub(super) struct GodotNodeUnmirroring;
+
 fn on_godot_node_handle_removed(
     trigger: On<Remove, GodotNodeHandle>,
-    query: Query<&GodotNodeHandle>,
+    query: Query<&GodotNodeHandle, Without<GodotNodeUnmirroring>>,
     mut godot: GodotAccess,
 ) {
     if let Ok(handle) = query.get(trigger.event_target())

--- a/godot-bevy/src/plugins/scene_tree/plugin.rs
+++ b/godot-bevy/src/plugins/scene_tree/plugin.rs
@@ -1,7 +1,8 @@
 use super::node_type_checking::{
     add_node_type_markers_from_string, remove_comprehensive_node_type_markers,
 };
-use crate::plugins::core::SceneTreeComponentRegistry;
+use super::relationship::{GodotChildOf, GodotChildren};
+use crate::plugins::core::{GodotNodeUnmirroring, SceneTreeComponentRegistry};
 use crate::prelude::GodotScene;
 use crate::watchers::scene_tree_watcher::is_excluded_from_mirror;
 use crate::{
@@ -133,13 +134,12 @@ impl NodeEntityIndex {
 /// This plugin is always included in the core plugins and provides
 /// complete scene tree integration out of the box.
 pub struct GodotSceneTreePlugin {
-    /// When true, despawning a parent entity will automatically despawn all children
-    /// via the GodotChildren on_despawn hook.
+    /// When true, despawning a parent entity also despawns its unprotected children
+    /// through the `GodotChildren` hook.
     ///
-    /// Set to false if you want to manually manage entity lifetimes independently
-    /// of the Godot scene tree (e.g., for object pooling or entities that outlive their nodes).
-    ///
-    /// `ProtectedNodeEntity` children are never despawned automatically.
+    /// This only controls the ECS cascade; nodes leaving the mirrored tree still
+    /// trigger cleanup of their entities.
+    /// Use `ProtectedNodeEntity` to retain entities after their nodes leave.
     pub auto_despawn_children: bool,
 }
 
@@ -155,13 +155,12 @@ impl Default for GodotSceneTreePlugin {
 #[derive(Resource, Reflect)]
 #[reflect(Resource)]
 pub struct SceneTreeConfig {
-    /// When true, despawning a parent entity will automatically despawn all children
-    /// via the GodotChildren on_despawn hook.
+    /// When true, despawning a parent entity also despawns its unprotected children
+    /// through the `GodotChildren` hook.
     ///
-    /// Set to false if you want to manually manage entity lifetimes independently
-    /// of the Godot scene tree (e.g., for object pooling or entities that outlive their nodes).
-    ///
-    /// `ProtectedNodeEntity` children are never despawned automatically.
+    /// This only controls the ECS cascade; nodes leaving the mirrored tree still
+    /// trigger cleanup of their entities.
+    /// Use `ProtectedNodeEntity` to retain entities after their nodes leave.
     pub auto_despawn_children: bool,
 }
 
@@ -600,10 +599,13 @@ fn write_scene_tree_messages(
     message_writer.write_batch(messages);
 }
 
-/// Marks an entity so it is not despawned when its corresponding Godot Node is freed, breaking
-/// the usual 1-to-1 lifetime between them. This allows game logic to keep running on entities
-/// that have no Node, such as simulating off-screen factory machines or NPCs in inactive scenes.
-/// A Godot Node can be re-associated later by adding a `GodotScene` component to the **entity.**
+/// Retains an entity when its Godot node is freed, detached, or moved into an excluded subtree.
+/// Cleanup removes its Godot components, index entry, and scene-tree relationships,
+/// preserving gameplay components. Detachment and exclusion do not free the node.
+///
+/// Reassociate a surviving node by inserting its `GodotNodeHandle` before re-entry,
+/// or add `GodotScene` to instantiate a replacement. Re-entry alone creates a fresh entity.
+/// Explicit entity despawn and explicit handle removal still queue the node for deletion.
 #[derive(Component)]
 pub struct ProtectedNodeEntity;
 
@@ -781,42 +783,19 @@ fn create_scene_tree_entity(
             }
             SceneTreeMessageType::NodeRemoved => {
                 if let Some(ent) = existing_entity {
-                    // During reparenting, the node is temporarily removed from old parent
-                    // but still exists in the scene tree (has a parent)
-                    // We need to try_get because the node handle might be invalid if freed
-                    let is_reparenting = godot
-                        .try_get::<Node>(node_handle)
-                        .map(|godot_node| godot_node.get_parent().is_some())
-                        .unwrap_or(false);
+                    let still_mirrored = godot.try_get::<Node>(node_handle).is_some_and(|node| {
+                        node.is_inside_tree() && !is_excluded_from_mirror(&node)
+                    });
 
-                    if is_reparenting {
-                        // A node reparented under an excluded subtree has its NodeAdded dropped
-                        // by the watcher, so preserving the entity here would strand it with a
-                        // stale parent and keep it syncing. Reconcile against exclusion: tear it
-                        // down instead. Otherwise it moved within the mirrored tree -- preserve it.
-                        let into_excluded = godot
-                            .try_get::<Node>(node_handle)
-                            .map(|n| is_excluded_from_mirror(&n))
-                            .unwrap_or(false);
-                        if into_excluded {
-                            commands.entity(ent).despawn();
-                            node_index.remove(instance_id);
-                        } else {
-                            trace!(target: "godot_scene_tree_events",
-                                "Node is being reparented, preserving entity");
-                        }
+                    if still_mirrored {
+                        trace!(target: "godot_scene_tree_events",
+                            "Node is being reparented, preserving entity");
                     } else {
-                        // Truly removed. Read protected from the world; same-batch
-                        // spawns aren't queryable yet but are never protected.
                         let protected = entities
                             .get(ent)
                             .map(|(_, _, prot, _)| prot.is_some())
                             .unwrap_or(false);
-                        if !protected {
-                            commands.entity(ent).despawn();
-                        } else {
-                            _strip_godot_components(commands, ent);
-                        }
+                        unmirror_node_entity(commands, ent, protected);
                         node_index.remove(instance_id);
                     }
                 } else {
@@ -1074,8 +1053,15 @@ fn warn_dead_contact_monitor(node: &Gd<Node>) {
          max_contacts_reported > 0 on this node to receive collision events.");
 }
 
-fn _strip_godot_components(commands: &mut Commands, ent: Entity) {
+fn unmirror_node_entity(commands: &mut Commands, ent: Entity, protected: bool) {
     let mut entity_commands = commands.entity(ent);
+    entity_commands.insert(GodotNodeUnmirroring);
+    // Unlink first so the parent's despawn hook cannot free live descendants.
+    entity_commands.remove::<(GodotChildOf, GodotChildren)>();
+    if !protected {
+        entity_commands.despawn();
+        return;
+    }
 
     entity_commands.remove::<GodotNodeHandle>();
     entity_commands.remove::<GodotScene>();
@@ -1084,6 +1070,7 @@ fn _strip_godot_components(commands: &mut Commands, ent: Entity) {
     entity_commands.remove::<SceneTreeDecorated>();
 
     remove_comprehensive_node_type_markers(&mut entity_commands);
+    entity_commands.remove::<GodotNodeUnmirroring>();
 }
 
 fn try_process_node_renamed_messages_fast_path(

--- a/godot-bevy/src/plugins/scene_tree/relationship.rs
+++ b/godot-bevy/src/plugins/scene_tree/relationship.rs
@@ -33,9 +33,10 @@ use bevy_reflect::Reflect;
 ///
 /// # Automatic Cleanup
 ///
-/// By default, when a parent entity is despawned, all children with `GodotChildOf` pointing
-/// to it will also be despawned. This can be configured via
-/// `GodotSceneTreePlugin::auto_despawn_children` or `SceneTreeConfig::auto_despawn_children`.
+/// By default, despawning a parent entity also despawns its unprotected children.
+/// Configure this ECS cascade with `GodotSceneTreePlugin::auto_despawn_children`
+/// or `SceneTreeConfig::auto_despawn_children`. Godot tree departures clean up each
+/// node's mirror independently and clear these relationships.
 #[derive(Component, Reflect, Clone, Copy, Debug, PartialEq, Eq)]
 #[reflect(Component)]
 #[relationship(relationship_target = GodotChildren)]

--- a/itest/faults/003-scene-remove-keeps-entity.patch
+++ b/itest/faults/003-scene-remove-keeps-entity.patch
@@ -1,12 +1,12 @@
 diff --git a/godot-bevy/src/plugins/scene_tree/plugin.rs b/godot-bevy/src/plugins/scene_tree/plugin.rs
 --- a/godot-bevy/src/plugins/scene_tree/plugin.rs
 +++ b/godot-bevy/src/plugins/scene_tree/plugin.rs
-@@ -837,7 +837,7 @@ fn process_scene_tree_messages(
-                             .map(|(_, _, prot, _)| prot.is_some())
-                             .unwrap_or(false);
-                         if !protected {
--                            commands.entity(ent).despawn();
-+                            _strip_godot_components(commands, ent);
-                         } else {
-                             _strip_godot_components(commands, ent);
-                         }
+@@ -1058,7 +1058,7 @@ fn unmirror_node_entity(commands: &mut Commands, ent: Entity, protected: bool) {
+     entity_commands.insert(GodotNodeUnmirroring);
+     // Unlink first so the parent's despawn hook cannot free live descendants.
+     entity_commands.remove::<(GodotChildOf, GodotChildren)>();
+-    if !protected {
++    if !protected && false {
+         entity_commands.despawn();
+         return;
+     }

--- a/itest/faults/004-scene-reparent-is-removal.patch
+++ b/itest/faults/004-scene-reparent-is-removal.patch
@@ -1,15 +1,14 @@
 diff --git a/godot-bevy/src/plugins/scene_tree/plugin.rs b/godot-bevy/src/plugins/scene_tree/plugin.rs
 --- a/godot-bevy/src/plugins/scene_tree/plugin.rs
 +++ b/godot-bevy/src/plugins/scene_tree/plugin.rs
-@@ -808,10 +808,7 @@ fn process_scene_tree_messages(
-                     // During reparenting, the node is temporarily removed from old parent
-                     // but still exists in the scene tree (has a parent)
-                     // We need to try_get because the node handle might be invalid if freed
--                    let is_reparenting = godot
--                        .try_get::<Node>(node_handle)
--                        .map(|godot_node| godot_node.get_parent().is_some())
--                        .unwrap_or(false);
-+                    let is_reparenting = false;
+@@ -783,9 +783,7 @@ fn create_scene_tree_entity(
+             }
+             SceneTreeMessageType::NodeRemoved => {
+                 if let Some(ent) = existing_entity {
+-                    let still_mirrored = godot.try_get::<Node>(node_handle).is_some_and(|node| {
+-                        node.is_inside_tree() && !is_excluded_from_mirror(&node)
+-                    });
++                    let still_mirrored = false;
  
-                     if is_reparenting {
-                         // A node reparented under an excluded subtree has its NodeAdded dropped
+                     if still_mirrored {
+                         trace!(target: "godot_scene_tree_events",

--- a/itest/rust/src/scene_tree_tests.rs
+++ b/itest/rust/src/scene_tree_tests.rs
@@ -362,7 +362,11 @@ fn test_node_reparenting_preserves_entity(ctx: &TestContext) -> godot::task::Tas
                 settle_scene_tree(&app).await;
 
                 assert_node_alive(child_id);
-                assert_eq!(app.entity_for_node(child_id), Some(entity));
+                assert_eq!(
+                    app.entity_for_node(child_id),
+                    Some(entity),
+                    "Entity should still exist after reparenting"
+                );
                 app.with_world(|world| {
                     assert_eq!(
                         world.get::<SceneTreePayload>(entity),
@@ -467,6 +471,10 @@ fn test_remove_child_despawns_entity(ctx: &TestContext) -> godot::task::TaskHand
         settle_scene_tree(&app).await;
 
         assert_node_alive(child_id);
+        assert!(
+            app.with_world(|world| world.get_entity(entity).is_err()),
+            "Entity should be despawned after remove_child()"
+        );
         assert_unmirrored(&app, child_id, entity, false);
         assert!(!child.is_inside_tree());
 

--- a/itest/rust/src/scene_tree_tests.rs
+++ b/itest/rust/src/scene_tree_tests.rs
@@ -1,8 +1,54 @@
-use godot::obj::NewAlloc;
+use bevy::prelude::{Component, Entity, Name};
+use godot::obj::{InstanceId, NewAlloc};
 use godot::prelude::*;
 use godot_bevy::plugins::scene_tree::ProtectedNodeEntity;
 use godot_bevy::prelude::*;
 use godot_bevy_test::prelude::*;
+
+#[derive(Component, Clone, Copy, Debug, PartialEq)]
+struct SceneTreePayload(i32);
+
+async fn settle_scene_tree(app: &TestApp) {
+    for _ in 0..4 {
+        app.physics_update().await;
+    }
+}
+
+fn assert_node_alive(id: InstanceId) {
+    let node = Gd::<Node>::try_from_instance_id(id).expect("node must remain valid");
+    assert!(
+        !node.is_queued_for_deletion(),
+        "node must not be queued for deletion"
+    );
+}
+
+fn assert_unmirrored(app: &TestApp, id: InstanceId, entity: Entity, protected: bool) {
+    assert_eq!(
+        app.entity_for_node(id),
+        None,
+        "departed node must leave the index"
+    );
+    app.with_world(|world| {
+        if protected {
+            assert_eq!(
+                world.get::<SceneTreePayload>(entity),
+                Some(&SceneTreePayload(42))
+            );
+            assert!(world.get::<ProtectedNodeEntity>(entity).is_some());
+            assert!(world.get::<GodotNodeHandle>(entity).is_none());
+            assert!(world.get::<GodotScene>(entity).is_none());
+            assert!(world.get::<Name>(entity).is_none());
+            assert!(world.get::<Groups>(entity).is_none());
+            assert!(world.get::<GodotChildOf>(entity).is_none());
+            assert!(world.get::<GodotChildren>(entity).is_none());
+        } else {
+            assert!(
+                world.get_entity(entity).is_err(),
+                "ordinary mirror entity must despawn"
+            );
+        }
+    });
+}
 
 #[itest(async)]
 fn test_node_added_creates_entity(ctx: &TestContext) -> godot::task::TaskHandle {
@@ -77,35 +123,31 @@ fn test_bevy_exclude_skips_subtree(ctx: &TestContext) -> godot::task::TaskHandle
     })
 }
 
-/// A node reparented under a subtree carrying `_bevy_exclude` is torn down: its
-/// NodeAdded is dropped by the watcher, so the entity must not linger with a stale
-/// parent and keep syncing.
 #[itest(async)]
 fn test_reparent_into_excluded_tears_down_entity(ctx: &TestContext) -> godot::task::TaskHandle {
     let ctx_clone = ctx.clone();
-
     godot::task::spawn(async move {
         let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
-
-        let (node, _entity) = app.add_node::<godot::classes::Node>("Reparented").await;
+        let (mut node, entity) = app.add_node::<Node>("Reparented").await;
         let node_id = node.instance_id();
-        assert!(
-            app.has_entity_for_node(node_id),
-            "node should be mirrored before the reparent"
-        );
-
+        let child = Node::new_alloc();
+        let child_id = child.instance_id();
+        node.add_child(&child);
         let mut excluded_parent = Node::new_alloc();
         excluded_parent.set_meta("_bevy_exclude", &true.to_variant());
         ctx_clone.scene_tree.clone().add_child(&excluded_parent);
-        app.updates(2).await;
+        settle_scene_tree(&app).await;
+        let child_entity = app.entity_for_node(child_id).expect("child entity");
 
-        node.clone().reparent(&excluded_parent);
-        app.updates(3).await;
+        node.reparent(&excluded_parent);
+        settle_scene_tree(&app).await;
 
-        assert!(
-            !app.has_entity_for_node(node_id),
-            "entity must be torn down after reparenting into an excluded subtree"
-        );
+        for (id, entity) in [(node_id, entity), (child_id, child_entity)] {
+            assert_node_alive(id);
+            assert_unmirrored(&app, id, entity, false);
+        }
+        assert_eq!(node.get_parent(), Some(excluded_parent.clone()));
+        assert_eq!(child.get_parent(), Some(node));
 
         app.cleanup().await;
         excluded_parent.free();
@@ -209,46 +251,38 @@ fn test_node_renamed_event(ctx: &TestContext) -> godot::task::TaskHandle {
 #[itest(async)]
 fn test_protected_node_entity(ctx: &TestContext) -> godot::task::TaskHandle {
     let ctx_clone = ctx.clone();
-
     godot::task::spawn(async move {
-        let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
+        for queued in [false, true] {
+            let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
+            let (mut node, entity) = app.add_node::<Node>("ProtectedNode").await;
+            let node_id = node.instance_id();
+            app.with_world_mut(|world| {
+                world
+                    .entity_mut(entity)
+                    .insert((ProtectedNodeEntity, SceneTreePayload(42)));
+            });
 
-        let (mut node, entity) = app
-            .add_node::<godot::classes::Node2D>("ProtectedNode")
-            .await;
+            if queued {
+                node.queue_free();
+                assert!(node.is_queued_for_deletion());
+            } else {
+                node.free();
+                assert!(!node_id.lookup_validity());
+            }
+            settle_scene_tree(&app).await;
 
-        let node_id = node.instance_id();
-
-        app.with_world_mut(|world| {
-            world.entity_mut(entity).insert(ProtectedNodeEntity);
-        });
-
-        node.queue_free();
-        app.updates(2).await;
-
-        let entity_still_exists = app.with_world(|world| world.get_entity(entity).is_ok());
-
-        assert!(
-            entity_still_exists,
-            "Protected entity should not be despawned when node is freed"
-        );
-
-        let handle_removed = app.with_world(|world| world.get::<GodotNodeHandle>(entity).is_none());
-
-        assert!(
-            handle_removed,
-            "GodotNodeHandle should be removed from protected entity"
-        );
-
-        let index_cleared =
-            app.with_world(|world| !world.resource::<NodeEntityIndex>().contains(node_id));
-
-        assert!(
-            index_cleared,
-            "NodeEntityIndex should remove entry for protected entity when node is freed"
-        );
-
-        app.cleanup().await;
+            assert!(!node_id.lookup_validity());
+            assert_eq!(app.entity_for_node(node_id), None);
+            app.with_world(|world| {
+                assert_eq!(
+                    world.get::<SceneTreePayload>(entity),
+                    Some(&SceneTreePayload(42))
+                );
+                assert!(world.get::<ProtectedNodeEntity>(entity).is_some());
+                assert!(world.get::<GodotNodeHandle>(entity).is_none());
+            });
+            app.cleanup().await;
+        }
     })
 }
 
@@ -301,66 +335,54 @@ fn test_node_handle_validity(ctx: &TestContext) -> godot::task::TaskHandle {
 #[itest(async)]
 fn test_node_reparenting_preserves_entity(ctx: &TestContext) -> godot::task::TaskHandle {
     let ctx_clone = ctx.clone();
-
     godot::task::spawn(async move {
-        let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
+        for protected in [false, true] {
+            for remove_add in [false, true] {
+                let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
+                let (mut parent1, _) = app.add_node::<Node>("Parent1").await;
+                let (mut parent2, parent2_entity) = app.add_node::<Node>("Parent2").await;
+                let mut child = Node::new_alloc();
+                let child_id = child.instance_id();
+                parent1.add_child(&child);
+                settle_scene_tree(&app).await;
+                let entity = app.entity_for_node(child_id).expect("child entity");
+                app.with_world_mut(|world| {
+                    world.entity_mut(entity).insert(SceneTreePayload(42));
+                    if protected {
+                        world.entity_mut(entity).insert(ProtectedNodeEntity);
+                    }
+                });
 
-        let mut parent1 = Node::new_alloc();
-        parent1.set_name("Parent1");
-        let mut parent2 = Node::new_alloc();
-        parent2.set_name("Parent2");
+                if remove_add {
+                    parent1.remove_child(&child);
+                    parent2.add_child(&child);
+                } else {
+                    child.reparent(&parent2);
+                }
+                settle_scene_tree(&app).await;
 
-        ctx_clone.scene_tree.clone().add_child(&parent1);
-        ctx_clone.scene_tree.clone().add_child(&parent2);
+                assert_node_alive(child_id);
+                assert_eq!(app.entity_for_node(child_id), Some(entity));
+                app.with_world(|world| {
+                    assert_eq!(
+                        world.get::<SceneTreePayload>(entity),
+                        Some(&SceneTreePayload(42))
+                    );
+                    assert_eq!(
+                        world.get::<GodotChildOf>(entity).map(GodotChildOf::get),
+                        Some(parent2_entity)
+                    );
+                    assert_eq!(
+                        world.get::<GodotNodeHandle>(entity).unwrap().instance_id(),
+                        child_id
+                    );
+                });
 
-        let mut child = Node::new_alloc();
-        child.set_name("Child");
-        parent1.clone().add_child(&child);
-
-        app.updates(2).await;
-
-        let entity = app
-            .entity_for_node(child.instance_id())
-            .expect("Child entity should exist");
-
-        #[derive(bevy::prelude::Component, Clone, Copy, Debug, PartialEq)]
-        struct CustomData(i32);
-
-        app.with_world_mut(|world| {
-            world.entity_mut(entity).insert(CustomData(42));
-        });
-
-        child.reparent(&parent2);
-        app.updates(2).await;
-
-        let entity_exists = app.with_world(|world| world.get_entity(entity).is_ok());
-
-        assert!(
-            entity_exists,
-            "Entity should still exist after reparenting (BUG: entity gets despawned)"
-        );
-
-        if entity_exists {
-            let data = app.with_world(|world| world.get::<CustomData>(entity).copied());
-            assert_eq!(
-                data,
-                Some(CustomData(42)),
-                "Component data should be preserved"
-            );
-
-            let child_id = child.instance_id();
-            let index_entity =
-                app.with_world(|world| world.resource::<NodeEntityIndex>().get(child_id));
-            assert_eq!(
-                index_entity,
-                Some(entity),
-                "NodeEntityIndex should still map to same entity after reparenting"
-            );
+                app.cleanup().await;
+                parent1.free();
+                parent2.free();
+            }
         }
-
-        app.cleanup().await;
-        parent1.free();
-        parent2.free();
     })
 }
 
@@ -432,35 +454,24 @@ fn test_reparent_preserves_registry_transform(ctx: &TestContext) -> godot::task:
 #[itest(async)]
 fn test_remove_child_despawns_entity(ctx: &TestContext) -> godot::task::TaskHandle {
     let ctx_clone = ctx.clone();
-
     godot::task::spawn(async move {
         let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
-
-        let mut parent = Node::new_alloc();
-        parent.set_name("RemoveChildParent");
-        ctx_clone.scene_tree.clone().add_child(&parent);
-
-        let mut child = Node::new_alloc();
-        child.set_name("RemoveChildTest");
-        parent.clone().add_child(&child);
-
-        app.updates(2).await;
-
-        let entity = app
-            .entity_for_node(child.instance_id())
-            .expect("Child entity should exist");
+        let (mut parent, _) = app.add_node::<Node>("RemoveChildParent").await;
+        let child = Node::new_alloc();
+        let child_id = child.instance_id();
+        parent.add_child(&child);
+        settle_scene_tree(&app).await;
+        let entity = app.entity_for_node(child_id).expect("child entity");
 
         parent.remove_child(&child);
-        app.updates(2).await;
+        settle_scene_tree(&app).await;
 
-        let entity_exists = app.with_world(|world| world.get_entity(entity).is_ok());
-
-        assert!(
-            !entity_exists,
-            "Entity should be despawned after remove_child()"
-        );
+        assert_node_alive(child_id);
+        assert_unmirrored(&app, child_id, entity, false);
+        assert!(!child.is_inside_tree());
 
         app.cleanup().await;
+        child.free();
         parent.free();
     })
 }
@@ -499,29 +510,18 @@ fn test_node_entity_index_populated_on_add(ctx: &TestContext) -> godot::task::Ta
 #[itest(async)]
 fn test_node_entity_index_updated_on_remove(ctx: &TestContext) -> godot::task::TaskHandle {
     let ctx_clone = ctx.clone();
-
     godot::task::spawn(async move {
         let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
-
-        let (mut node, _entity) = app
-            .add_node::<godot::classes::Node2D>("IndexRemovalTestNode")
-            .await;
-
+        let (mut node, entity) = app.add_node::<Node>("IndexRemovalTestNode").await;
         let node_id = node.instance_id();
-
-        assert!(
-            app.has_entity_for_node(node_id),
-            "Node should be in index after add"
-        );
+        assert_eq!(app.entity_for_node(node_id), Some(entity));
 
         node.queue_free();
-        app.updates(2).await;
+        assert!(node.is_queued_for_deletion());
+        settle_scene_tree(&app).await;
 
-        assert!(
-            !app.has_entity_for_node(node_id),
-            "NodeEntityIndex should remove entry when node is freed"
-        );
-
+        assert!(!node_id.lookup_validity());
+        assert_unmirrored(&app, node_id, entity, false);
         app.cleanup().await;
     })
 }
@@ -580,5 +580,501 @@ fn test_packed_scene_spawn_reconciles_to_single_entity(
         }
         app.updates(2).await;
         app.cleanup().await;
+    })
+}
+
+#[itest(async)]
+fn test_protected_detach_preserves_node(ctx: &TestContext) -> godot::task::TaskHandle {
+    let ctx_clone = ctx.clone();
+    godot::task::spawn(async move {
+        let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
+        let (mut parent, parent_entity) = app.add_node::<Node>("ProtectedDetachParent").await;
+        let child = Node::new_alloc();
+        let child_id = child.instance_id();
+        parent.add_child(&child);
+        settle_scene_tree(&app).await;
+        let entity = app.entity_for_node(child_id).expect("child entity");
+        app.with_world_mut(|world| {
+            assert_eq!(
+                world.get::<GodotChildOf>(entity).map(GodotChildOf::get),
+                Some(parent_entity)
+            );
+            world
+                .entity_mut(entity)
+                .insert((ProtectedNodeEntity, SceneTreePayload(42)));
+        });
+
+        parent.remove_child(&child);
+        settle_scene_tree(&app).await;
+
+        assert_node_alive(child_id);
+        assert_unmirrored(&app, child_id, entity, true);
+        app.with_world(|world| {
+            assert!(
+                !world
+                    .get::<GodotChildren>(parent_entity)
+                    .is_some_and(|children| children.contains(entity))
+            );
+        });
+        app.cleanup().await;
+        child.free();
+        parent.free();
+    })
+}
+
+#[itest(async)]
+fn test_detached_subtree_cleanup(ctx: &TestContext) -> godot::task::TaskHandle {
+    let ctx_clone = ctx.clone();
+    godot::task::spawn(async move {
+        for auto_despawn_children in [true, false] {
+            for protected_root in [false, true] {
+                for protected_child in [false, true] {
+                    let mut app = TestApp::new(&ctx_clone, move |app| {
+                        app.world_mut()
+                            .resource_mut::<SceneTreeConfig>()
+                            .auto_despawn_children = auto_despawn_children;
+                    })
+                    .await;
+                    let (mut parent, _) = app.add_node::<Node>("SubtreeParent").await;
+                    let mut node = Node::new_alloc();
+                    let mut child = Node::new_alloc();
+                    let grandchild = Node::new_alloc();
+                    child.add_child(&grandchild);
+                    node.add_child(&child);
+                    parent.add_child(&node);
+                    settle_scene_tree(&app).await;
+                    let members = [
+                        (&node, protected_root),
+                        (&child, protected_child),
+                        (&grandchild, !protected_child),
+                    ]
+                    .map(|(node, protected)| {
+                        let id = node.instance_id();
+                        let entity = app.entity_for_node(id).expect("subtree entity");
+                        app.with_world_mut(|world| {
+                            world.entity_mut(entity).insert(SceneTreePayload(42));
+                            if protected {
+                                world.entity_mut(entity).insert(ProtectedNodeEntity);
+                            }
+                        });
+                        (id, entity, protected)
+                    });
+
+                    parent.remove_child(&node);
+                    settle_scene_tree(&app).await;
+
+                    for (id, entity, protected) in members {
+                        assert_node_alive(id);
+                        assert_unmirrored(&app, id, entity, protected);
+                    }
+                    assert!(!node.is_inside_tree());
+                    assert_eq!(child.get_parent(), Some(node.clone()));
+                    assert_eq!(grandchild.get_parent(), Some(child));
+
+                    app.cleanup().await;
+                    node.free();
+                    parent.free();
+                }
+            }
+        }
+    })
+}
+
+#[itest(async)]
+fn test_reparent_to_detached_parent(ctx: &TestContext) -> godot::task::TaskHandle {
+    let ctx_clone = ctx.clone();
+    godot::task::spawn(async move {
+        let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
+        let (mut node, entity) = app.add_node::<Node>("OfflineReparent").await;
+        let node_id = node.instance_id();
+        let offline_parent = Node::new_alloc();
+
+        node.reparent(&offline_parent);
+        settle_scene_tree(&app).await;
+
+        assert_node_alive(node_id);
+        assert_unmirrored(&app, node_id, entity, false);
+        assert!(!node.is_inside_tree());
+        assert_eq!(node.get_parent(), Some(offline_parent.clone()));
+
+        app.cleanup().await;
+        offline_parent.free();
+    })
+}
+
+#[itest(async)]
+fn test_protected_reparent_into_excluded(ctx: &TestContext) -> godot::task::TaskHandle {
+    let ctx_clone = ctx.clone();
+    godot::task::spawn(async move {
+        let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
+        let (mut node, entity) = app.add_node::<Node>("ProtectedExcluded").await;
+        let node_id = node.instance_id();
+        let child = Node::new_alloc();
+        let child_id = child.instance_id();
+        node.add_child(&child);
+        let mut excluded_parent = Node::new_alloc();
+        excluded_parent.set_meta("_bevy_exclude", &true.to_variant());
+        ctx_clone.scene_tree.clone().add_child(&excluded_parent);
+        settle_scene_tree(&app).await;
+        let child_entity = app.entity_for_node(child_id).expect("child entity");
+        app.with_world_mut(|world| {
+            for entity in [entity, child_entity] {
+                world
+                    .entity_mut(entity)
+                    .insert((ProtectedNodeEntity, SceneTreePayload(42)));
+            }
+        });
+
+        node.reparent(&excluded_parent);
+        settle_scene_tree(&app).await;
+
+        for (id, entity) in [(node_id, entity), (child_id, child_entity)] {
+            assert_node_alive(id);
+            assert_unmirrored(&app, id, entity, true);
+        }
+        assert_eq!(node.get_parent(), Some(excluded_parent.clone()));
+        assert_eq!(child.get_parent(), Some(node));
+
+        app.cleanup().await;
+        excluded_parent.free();
+    })
+}
+
+#[itest(async)]
+fn test_reparent_out_of_excluded_creates_entities(ctx: &TestContext) -> godot::task::TaskHandle {
+    let ctx_clone = ctx.clone();
+    godot::task::spawn(async move {
+        let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
+        let mut excluded_parent = Node::new_alloc();
+        excluded_parent.set_meta("_bevy_exclude", &true.to_variant());
+        let mut node = Node::new_alloc();
+        let child = Node::new_alloc();
+        let node_id = node.instance_id();
+        let child_id = child.instance_id();
+        node.add_child(&child);
+        excluded_parent.add_child(&node);
+        ctx_clone.scene_tree.clone().add_child(&excluded_parent);
+        let (destination, destination_entity) = app.add_node::<Node>("IncludedParent").await;
+        settle_scene_tree(&app).await;
+        assert_eq!(app.entity_for_node(node_id), None);
+        assert_eq!(app.entity_for_node(child_id), None);
+
+        node.reparent(&destination);
+        settle_scene_tree(&app).await;
+
+        assert_node_alive(node_id);
+        assert_node_alive(child_id);
+        let entity = app
+            .entity_for_node(node_id)
+            .expect("node must enter the mirror");
+        let child_entity = app
+            .entity_for_node(child_id)
+            .expect("child must enter the mirror");
+        app.with_world(|world| {
+            assert_eq!(
+                world.get::<GodotNodeHandle>(entity).unwrap().instance_id(),
+                node_id
+            );
+            assert_eq!(
+                world
+                    .get::<GodotNodeHandle>(child_entity)
+                    .unwrap()
+                    .instance_id(),
+                child_id
+            );
+            assert_eq!(
+                world.get::<GodotChildOf>(entity).map(GodotChildOf::get),
+                Some(destination_entity)
+            );
+            assert_eq!(
+                world
+                    .get::<GodotChildOf>(child_entity)
+                    .map(GodotChildOf::get),
+                Some(entity)
+            );
+        });
+
+        app.cleanup().await;
+        excluded_parent.free();
+        destination.free();
+    })
+}
+
+#[itest(async)]
+fn test_excluded_detach_preserves_node(ctx: &TestContext) -> godot::task::TaskHandle {
+    let ctx_clone = ctx.clone();
+    godot::task::spawn(async move {
+        let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
+        let mut excluded_parent = Node::new_alloc();
+        excluded_parent.set_meta("_bevy_exclude", &true.to_variant());
+        let mut node = Node::new_alloc();
+        let child = Node::new_alloc();
+        let ids = [node.instance_id(), child.instance_id()];
+        node.add_child(&child);
+        excluded_parent.add_child(&node);
+        ctx_clone.scene_tree.clone().add_child(&excluded_parent);
+        settle_scene_tree(&app).await;
+        for id in ids {
+            assert_eq!(app.entity_for_node(id), None);
+        }
+
+        excluded_parent.remove_child(&node);
+        settle_scene_tree(&app).await;
+
+        for id in ids {
+            assert_node_alive(id);
+            assert_eq!(app.entity_for_node(id), None);
+        }
+        app.cleanup().await;
+        node.free();
+        excluded_parent.free();
+    })
+}
+
+#[itest(async)]
+fn test_detached_node_reenters_tree(ctx: &TestContext) -> godot::task::TaskHandle {
+    let ctx_clone = ctx.clone();
+    godot::task::spawn(async move {
+        for protected in [false, true] {
+            let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
+            let (mut parent, _) = app.add_node::<Node>("ReentryParent").await;
+            let node = Node::new_alloc();
+            let node_id = node.instance_id();
+            parent.add_child(&node);
+            settle_scene_tree(&app).await;
+            let old_entity = app.entity_for_node(node_id).expect("initial entity");
+            app.with_world_mut(|world| {
+                world.entity_mut(old_entity).insert(SceneTreePayload(42));
+                if protected {
+                    world.entity_mut(old_entity).insert(ProtectedNodeEntity);
+                }
+            });
+
+            parent.remove_child(&node);
+            settle_scene_tree(&app).await;
+            assert_node_alive(node_id);
+            assert_unmirrored(&app, node_id, old_entity, protected);
+
+            parent.add_child(&node);
+            settle_scene_tree(&app).await;
+
+            assert_node_alive(node_id);
+            assert_eq!(node.instance_id(), node_id);
+            let new_entity = app.entity_for_node(node_id).expect("reentry entity");
+            assert_ne!(new_entity, old_entity);
+            app.with_world(|world| {
+                assert!(world.get::<SceneTreePayload>(new_entity).is_none());
+                assert_eq!(
+                    world
+                        .get::<GodotNodeHandle>(new_entity)
+                        .unwrap()
+                        .instance_id(),
+                    node_id
+                );
+                if protected {
+                    assert_eq!(
+                        world.get::<SceneTreePayload>(old_entity),
+                        Some(&SceneTreePayload(42))
+                    );
+                    assert!(world.get::<GodotNodeHandle>(old_entity).is_none());
+                } else {
+                    assert!(world.get_entity(old_entity).is_err());
+                }
+            });
+            app.cleanup().await;
+            parent.free();
+        }
+    })
+}
+
+#[itest(async)]
+fn test_protected_rebind_then_despawn(ctx: &TestContext) -> godot::task::TaskHandle {
+    let ctx_clone = ctx.clone();
+    godot::task::spawn(async move {
+        for reattach in [false, true] {
+            let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
+            let (mut parent, _) = app.add_node::<Node>("RebindParent").await;
+            let node = Node::new_alloc();
+            let node_id = node.instance_id();
+            parent.add_child(&node);
+            settle_scene_tree(&app).await;
+            let entity = app.entity_for_node(node_id).expect("initial entity");
+            app.with_world_mut(|world| {
+                world
+                    .entity_mut(entity)
+                    .insert((ProtectedNodeEntity, SceneTreePayload(42)));
+            });
+
+            parent.remove_child(&node);
+            settle_scene_tree(&app).await;
+            assert_node_alive(node_id);
+            assert_unmirrored(&app, node_id, entity, true);
+            app.with_world_mut(|world| {
+                world
+                    .entity_mut(entity)
+                    .insert(GodotNodeHandle::from(node_id));
+            });
+            if reattach {
+                parent.add_child(&node);
+                settle_scene_tree(&app).await;
+            }
+            assert_eq!(app.entity_for_node(node_id), Some(entity));
+            app.with_world_mut(|world| {
+                assert_eq!(
+                    world.get::<SceneTreePayload>(entity),
+                    Some(&SceneTreePayload(42))
+                );
+                world.entity_mut(entity).despawn();
+            });
+            assert!(node.is_queued_for_deletion());
+            settle_scene_tree(&app).await;
+
+            assert!(!node_id.lookup_validity());
+            assert_unmirrored(&app, node_id, entity, false);
+            app.cleanup().await;
+            parent.free();
+        }
+    })
+}
+
+#[itest(async)]
+fn test_ecs_despawn_frees_node(ctx: &TestContext) -> godot::task::TaskHandle {
+    let ctx_clone = ctx.clone();
+    godot::task::spawn(async move {
+        for protected in [false, true] {
+            for detach in [false, true] {
+                let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
+                let (mut parent, _) = app.add_node::<Node>("DespawnParent").await;
+                let node = Node::new_alloc();
+                let node_id = node.instance_id();
+                parent.add_child(&node);
+                settle_scene_tree(&app).await;
+                let entity = app.entity_for_node(node_id).expect("node entity");
+                app.with_world_mut(|world| {
+                    if protected {
+                        world.entity_mut(entity).insert(ProtectedNodeEntity);
+                    }
+                });
+
+                if detach {
+                    parent.remove_child(&node);
+                }
+                app.with_world_mut(|world| {
+                    world.entity_mut(entity).despawn();
+                });
+                assert!(node.is_queued_for_deletion());
+                settle_scene_tree(&app).await;
+
+                assert!(!node_id.lookup_validity());
+                assert_unmirrored(&app, node_id, entity, false);
+                app.cleanup().await;
+                parent.free();
+            }
+        }
+    })
+}
+
+#[itest(async)]
+fn test_handle_removal_frees_node(ctx: &TestContext) -> godot::task::TaskHandle {
+    let ctx_clone = ctx.clone();
+    godot::task::spawn(async move {
+        for protected in [false, true] {
+            for detach in [false, true] {
+                let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
+                let (mut parent, _) = app.add_node::<Node>("HandleRemovalParent").await;
+                let node = Node::new_alloc();
+                let node_id = node.instance_id();
+                parent.add_child(&node);
+                settle_scene_tree(&app).await;
+                let entity = app.entity_for_node(node_id).expect("node entity");
+                app.with_world_mut(|world| {
+                    world.entity_mut(entity).insert(SceneTreePayload(42));
+                    if protected {
+                        world.entity_mut(entity).insert(ProtectedNodeEntity);
+                    }
+                });
+
+                if detach {
+                    parent.remove_child(&node);
+                }
+                app.with_world_mut(|world| {
+                    world.entity_mut(entity).remove::<GodotNodeHandle>();
+                });
+                assert!(node.is_queued_for_deletion());
+                settle_scene_tree(&app).await;
+
+                assert!(!node_id.lookup_validity());
+                assert_eq!(app.entity_for_node(node_id), None);
+                app.with_world(|world| {
+                    assert_eq!(
+                        world.get::<SceneTreePayload>(entity),
+                        Some(&SceneTreePayload(42))
+                    );
+                    assert!(world.get::<GodotNodeHandle>(entity).is_none());
+                });
+                app.cleanup().await;
+                parent.free();
+            }
+        }
+    })
+}
+
+#[itest(async)]
+fn test_free_cleans_up_entity(ctx: &TestContext) -> godot::task::TaskHandle {
+    let ctx_clone = ctx.clone();
+    godot::task::spawn(async move {
+        let mut app = TestApp::new(&ctx_clone, |_app| {}).await;
+        let (node, entity) = app.add_node::<Node>("ImmediateFree").await;
+        let node_id = node.instance_id();
+
+        node.free();
+        assert!(!node_id.lookup_validity());
+        settle_scene_tree(&app).await;
+
+        assert_unmirrored(&app, node_id, entity, false);
+        app.cleanup().await;
+    })
+}
+
+#[itest(async)]
+fn test_ecs_parent_despawn_with_auto_children_disabled(
+    ctx: &TestContext,
+) -> godot::task::TaskHandle {
+    let ctx_clone = ctx.clone();
+    godot::task::spawn(async move {
+        for protected_child in [false, true] {
+            let mut app = TestApp::new(&ctx_clone, |app| {
+                app.world_mut()
+                    .resource_mut::<SceneTreeConfig>()
+                    .auto_despawn_children = false;
+            })
+            .await;
+            let (mut parent, parent_entity) = app.add_node::<Node>("NoCascadeParent").await;
+            let parent_id = parent.instance_id();
+            let child = Node::new_alloc();
+            let child_id = child.instance_id();
+            parent.add_child(&child);
+            settle_scene_tree(&app).await;
+            let child_entity = app.entity_for_node(child_id).expect("child entity");
+            app.with_world_mut(|world| {
+                world.entity_mut(child_entity).insert(SceneTreePayload(42));
+                if protected_child {
+                    world.entity_mut(child_entity).insert(ProtectedNodeEntity);
+                }
+                world.entity_mut(parent_entity).despawn();
+                assert!(
+                    world.get_entity(child_entity).is_ok(),
+                    "ECS cascade must be disabled"
+                );
+            });
+            assert!(parent.is_queued_for_deletion());
+            settle_scene_tree(&app).await;
+
+            assert!(!parent_id.lookup_validity());
+            assert!(!child_id.lookup_validity());
+            assert_unmirrored(&app, parent_id, parent_entity, false);
+            assert_unmirrored(&app, child_id, child_entity, protected_child);
+            app.cleanup().await;
+        }
     })
 }


### PR DESCRIPTION
Detaching a mirrored node with `remove_child` destroyed it: the scene-tree drain despawned the entity, and the `On<Remove, GodotNodeHandle>` observer in core then queue-freed the node. So pooling a node, or pulling it out of the tree to move it later, silently freed it a frame later. Two more on the same path: descendants of a detached root were classified as "reparented" because the check was only `get_parent().is_some()`, so they kept stale handles, and `ProtectedNodeEntity` went through the same observer, so protected nodes got freed on detach too. Nothing in the existing tests noticed because `test_remove_child_despawns_entity` never checked whether the child was still alive.

The fix keeps the contract that ECS-side despawn (and explicit handle removal) frees the node, and stops Godot-side departures from doing so. Automatic teardown inserts a private marker right before it despawns or strips, and the observer skips marked entities. Departures are classified by `is_inside_tree()` plus exclusion instead of parent presence, which is what fixes the subtree case. Relationships are unlinked before teardown so a parent's despawn can't cascade into freeing live child nodes.

What changes for users: a detached node is now yours to free or re-add. Its entity still despawns (the mirror follows tree membership), and a re-added node gets a fresh entity. Protected entities keep their gameplay components and lose their Godot handle, index entry and relationships. The timing and exclusion pages in the book say all of this.

Tests: `test_remove_child_despawns_entity` now asserts the child is a valid, unqueued instance and fails on main; seven more new failing-first tests cover protected detach, detached subtrees under both `auto_despawn_children` values, reparent to a detached parent, moves into exclusion, re-entry, and rebinding a protected survivor. Nine controls pin the behaviour that must not change: ECS despawn frees, `free`/`queue_free` clean up, reparent preserves identity, the protected-entity test.
