### PR TITLE
Build on every advertised Godot API level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,38 @@ jobs:
           cargo test --lib --bins --examples
           cargo test --doc -p godot-bevy -p godot-bevy-macros -p godot-bevy-test -p godot-bevy-test-macros
 
+  api-levels:
+    name: api levels
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.library == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        api: [api-4-2, api-4-3, api-4-4, api-4-5, api-4-6]
+        feature-flags: ["", "--no-default-features"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.api }}-${{ matrix.feature-flags }}
+          workspaces: . -> target
+
+      - name: Cache and install Linux dependencies
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libasound2-dev libudev-dev pkg-config
+          version: 1.0
+
+      - name: Check API level
+        run: cargo check -p godot-bevy ${{ matrix.feature-flags }} --features ${{ matrix.api }}
+
   changes:
     name: detect changes
     runs-on: ubuntu-latest

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -101,7 +101,7 @@ bevy = { version = "0.18", default-features = false }
 godot = "0.4"
 ```
 
-godot-bevy supports Godot API levels 4.2 through 4.6 via the mutually exclusive Cargo features `api-4-2`, `api-4-3`, `api-4-4`, `api-4-5`, and `api-4-6`, with or without default features.
+godot-bevy supports Godot API levels 4.2 through 4.6 via the mutually exclusive Cargo features `api-4-2`, `api-4-3`, `api-4-4`, `api-4-5`, and `api-4-6`, with or without default features. Set `compatibility_minimum` in your `.gdextension` file to the level you build against; the example below assumes 4.3.
 
 ## Configure Godot Integration
 

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -101,6 +101,8 @@ bevy = { version = "0.18", default-features = false }
 godot = "0.4"
 ```
 
+godot-bevy supports Godot API levels 4.2 through 4.6 via the mutually exclusive Cargo features `api-4-2`, `api-4-3`, `api-4-4`, `api-4-5`, and `api-4-6`, with or without default features.
+
 ## Configure Godot Integration
 
 ### 1. Create Extension File

--- a/godot-bevy/Cargo.toml
+++ b/godot-bevy/Cargo.toml
@@ -16,7 +16,7 @@ bevy_asset = {version = "0.19", default-features = false}
 bevy_diagnostic = {version = "0.19", default-features = false}
 bevy_ecs = {version = "0.19", default-features = false, features = ["multi_threaded", "bevy_reflect"]}
 bevy_input = {version = "0.19", default-features = false, features = ["gestures", "keyboard", "mouse"]}
-bevy_math = {version = "0.19", default-features = false}
+bevy_math = {version = "0.19", default-features = false, features = ["std"]}
 bevy_platform = {version = "0.19", default-features = false, features = ["alloc"]}
 bevy_reflect = {version = "0.19", default-features = false}
 bevy_tasks = {version = "0.19", default-features = false, features = ["multi_threaded"]}

--- a/godot-bevy/src/plugins/input/events.rs
+++ b/godot-bevy/src/plugins/input/events.rs
@@ -214,7 +214,7 @@ fn extract_basic_input_events(
                 pressed: key_event.is_pressed(),
                 echo: key_event.is_echo(),
                 #[cfg(any(feature = "api-4-2", feature = "api-4-3"))]
-                unicode: key_event.get_unicode() as u32,
+                unicode: u32::try_from(key_event.get_unicode()).unwrap_or_default(),
                 #[cfg(not(any(feature = "api-4-2", feature = "api-4-3")))]
                 unicode: key_event.get_unicode(),
             });

--- a/godot-bevy/src/plugins/input/events.rs
+++ b/godot-bevy/src/plugins/input/events.rs
@@ -213,6 +213,9 @@ fn extract_basic_input_events(
                 physical_keycode: Some(key_event.get_physical_keycode()),
                 pressed: key_event.is_pressed(),
                 echo: key_event.is_echo(),
+                #[cfg(any(feature = "api-4-2", feature = "api-4-3"))]
+                unicode: key_event.get_unicode() as u32,
+                #[cfg(not(any(feature = "api-4-2", feature = "api-4-3")))]
                 unicode: key_event.get_unicode(),
             });
             return;

--- a/godot-bevy/src/plugins/transforms/sync_systems.rs
+++ b/godot-bevy/src/plugins/transforms/sync_systems.rs
@@ -7,7 +7,10 @@ use bevy_ecs::query::{AnyOf, Changed, QueryFilter};
 use bevy_ecs::system::Query;
 use bevy_math::Quat;
 use bevy_transform::components::Transform as BevyTransform;
-use godot::classes::{Engine, Node, Node2D, Node3D, SceneTree};
+#[cfg(not(feature = "api-4-2"))]
+use godot::classes::{Engine, Node, SceneTree};
+use godot::classes::{Node2D, Node3D};
+#[cfg(not(feature = "api-4-2"))]
 use godot::obj::Singleton;
 
 use super::change_filter::TransformSyncMetadata;
@@ -119,6 +122,7 @@ pub fn post_update_godot_transforms<F: QueryFilter>(
     mut godot: GodotAccess,
 ) {
     // Read once per system run to avoid per-entity FFI.
+    #[cfg(not(feature = "api-4-2"))]
     let fti_enabled = physics_interpolation_enabled();
 
     for (transform_ref, reference, mut metadata, (node2d, node3d)) in entities.iter_mut() {
@@ -146,6 +150,7 @@ pub fn post_update_godot_transforms<F: QueryFilter>(
         metadata.shadow = *transform_ref;
         if is_first_write {
             metadata.written_once = true;
+            #[cfg(not(feature = "api-4-2"))]
             if fti_enabled && let Some(mut node) = godot.try_get::<Node>(*reference) {
                 node.reset_physics_interpolation();
             }
@@ -153,6 +158,7 @@ pub fn post_update_godot_transforms<F: QueryFilter>(
     }
 }
 
+#[cfg(not(feature = "api-4-2"))]
 fn physics_interpolation_enabled() -> bool {
     Engine::singleton()
         .get_main_loop()


### PR DESCRIPTION
`api-4-2` through `api-4-6` are advertised as features but nothing built them, and 7 of the 10 forms (each level, with and without default features) failed on main: every `--no-default-features` build had no `bevy_math` backend, 4.2 and 4.3 get an `i64` from `InputEventKey::get_unicode` where later levels get `u32`, and 4.2 has no physics-interpolation methods on `Node`/`SceneTree`.

Fixes are minimal: `bevy_math/std` on our own dependency (the default build already had it via gilrs → bevy_input), a cfg on the unicode field for 4.2/4.3, and the interpolation query and reset cfg'd out on 4.2. Generated per-version files and the default level are unchanged.

A new `api levels` CI job checks all ten forms with `cargo check`, gated on the existing library filter, no Godot needed. One sentence in the installation page states the supported range.
