### PR TITLE
editor-probe: manifests, property assertions, and editor-help check

### DIFF
--- a/.claude/skills/editor-probe/SKILL.md
+++ b/.claude/skills/editor-probe/SKILL.md
@@ -1,25 +1,43 @@
 ---
-description: Verify an Inspector-facing change in the real Godot editor - instantiate a GDExtension class in a scene, edit an exported property, save, reload, and capture editor screenshots, all scripted
+name: editor-probe
+description: Verify editor-facing Godot classes in a real editor with property assertions, scene save/reload, Inspector screenshots, and optional help text checks
 ---
 
 # Editor probe
 
-The itest suite runs in a real headless Godot, so it covers runtime behaviour. It cannot show
-that a class appears in the editor, that its `#[export]` fields render in the Inspector, or that
-an edited value survives save and reload. This skill does that with a temporary `@tool`
-`EditorPlugin`, driven end to end with no clicking, and captures the editor's own viewport as
-PNGs (no OS screenshot permission needed).
+Use this after changing a class, exported field, Inspector hint, or property description that
+designers see in the editor. A temporary `@tool` plugin instantiates the class, checks its
+property metadata and default, edits a value, saves and reloads a scene, and captures the
+Inspector. Runtime itests do not cover the editor UI.
 
-Use it after adding or changing a `GodotClass` that designers touch in the editor: an
-`AttachableComponent` carrier, a `#[derive(GodotNode)]` class with exported fields, a new
-Inspector hint. It proves the class registers, the property shows with its default, an edit
-sticks, and the saved `.tscn` carries the value.
+## Prepare the project
 
-## Run
+Use Godot 4.6 with a display. On the hub, use a session attached to the GUI, not a bare SSH
+shell. Run commands through `devenv shell --`. Check `df -h "/Volumes/DS Vault"` before builds.
+The hub's `target/` is a shared symlink. Never run `cargo clean`.
 
-The class must already be compiled into the project's GDExtension; build it the way the project
-normally is built (for an example, `cargo run --features itest --manifest-path
-examples/<name>/rust/Cargo.toml` builds and imports it). Then:
+Build the classes into the project's GDExtension before probing. For the platformer:
+
+```bash
+devenv shell -- cargo run --features itest --manifest-path examples/platformer-2d/rust/Cargo.toml
+```
+
+For itest, the runner builds the library, generates `itest/godot/itest.gdextension`, imports the
+project, and runs the selected test:
+
+```bash
+devenv shell -- ./itest/run-tests.sh --filter inspector_metadata_roundtrip
+```
+
+It builds with `--features test-frame-signal,autosync-tests`. The itest crate already enables
+`godot-bevy/register-docs`. A manual build alone does not generate its `.gdextension`.
+
+Help assertions require `godot-bevy/register-docs` compiled into the extension. Enable that
+feature when preparing other crates whose probes check descriptions. Build and import
+perf-test with `devenv shell -- cargo run --manifest-path examples/perf-test/rust/Cargo.toml`,
+then close the running example before probing.
+
+## Run one probe
 
 ```bash
 devenv shell -- .claude/skills/editor-probe/scripts/run.sh examples/platformer-2d/godot probe.json
@@ -34,34 +52,83 @@ devenv shell -- .claude/skills/editor-probe/scripts/run.sh examples/platformer-2
   "root": "Node2D",
   "property": "multiplier",
   "value": 3.0,
-  "shots": "/tmp/editor-probe/shots"
+  "expect": {
+    "type": "FLOAT",
+    "hint": "NONE",
+    "hint_string": "",
+    "default": 1.5
+  },
+  "shots": "/tmp/editor-probe/JumpBoostCarrier"
 }
 ```
 
-The driver enables a temporary plugin in `project.godot`, launches `godot --editor` on the
-project, waits for it to finish, and prints the probe's output. Exit codes: 0 the reloaded
-value matched, 3 the class does not exist in the editor, 4 the value did not survive reload,
-5 the editor did not finish within the timeout. It restores `project.godot`, removes the plugin
-and the probe scene, and reverts `.import` files the editor rewrote, so `git status` is clean
-afterwards. Screenshots land in `shots/` as `1-default.png`, `2-edited.png`, `3-reloaded.png`;
-read them and look at the Inspector panel.
+`class`, `property`, `value`, and `shots` are required. `root` defaults to `Node2D` and
+`node_name` to `Probe`. Use an absolute `shots` path. Values and defaults must be representable
+in JSON, such as numbers, strings, and booleans.
 
-## What it does inside the editor
+All `expect` keys are optional. The plugin finds `property` in `get_property_list()` and checks
+`type`, `hint`, and `hint_string` against that entry. Use Variant.Type names such as `FLOAT`
+or `STRING`, and PropertyHint names such as `RANGE` or `ENUM`, without `TYPE_` or
+`PROPERTY_HINT_` prefixes. `default` is read from the fresh node before editing. Missing keys
+are not checked. Every mismatch appears in the probe's verdict line.
 
-Instantiates `root` with one child of `class`, saves it as `res://scenes/editor_probe.tscn`,
-opens it, selects the child so the Inspector shows it, captures, sets `property` to `value`,
-captures, saves, reloads the scene from disk, reads the property back, captures, and quits with
-the verdict.
+To check help text, add `"description": "Primary kind description"` inside `expect`.
+The plugin calls
+`EditorInterface.get_script_editor().goto_help("class_property:<class>:<property>")`, waits,
+and checks that the visible help label contains the description. This traversal is pinned to
+Godot 4.6: a visible `EditorHelp` below `ScriptEditor`, with a direct visible `RichTextLabel`
+child. It fails clearly if the version differs or the label is missing.
+The structure comes from [Godot 4.6's EditorHelp constructor](https://github.com/godotengine/godot/blob/4.6-stable/editor/doc/editor_help.cpp).
 
-## Traps
+## Run a manifest
 
-- The editor needs a display. On a headless box there is nothing to capture; on the hub run it
-  from a session attached to the GUI (the tmux session), not a bare SSH shell.
-- The editor only redraws on input. Captures use `RenderingServer.force_draw()`; waiting on
-  `frame_post_draw` hangs forever.
-- `EditorScript` cannot be run from the command line; that is why this is a plugin toggled in
-  `project.godot`.
-- Godot rewrites `.import` files on every editor start. The driver reverts them; if you adapt
-  it, keep that step or you will commit noise.
-- The Godot import step can crash on exit with a GDExtension loaded (godotengine/godot#111645).
-  The driver uses the verdict the probe prints, so a crash after it does not turn a pass into a failure.
+A manifest is a JSON list of probes. Each probe has the same fields as above plus `project`,
+a path relative to the repo root, such as `examples/platformer-2d/godot` or `itest/godot`.
+Give each probe its own `shots` directory.
+
+```bash
+devenv shell -- .claude/skills/editor-probe/scripts/run.sh --manifest .claude/skills/editor-probe/manifests/platformer-2d.json
+devenv shell -- .claude/skills/editor-probe/scripts/run.sh --manifest .claude/skills/editor-probe/manifests/itest.json
+devenv shell -- .claude/skills/editor-probe/scripts/run.sh --manifest .claude/skills/editor-probe/manifests/perf-test.json
+```
+
+The driver groups probes by project in first-seen order. It launches one editor per project,
+runs that project's probes inside the plugin, then cleans up before launching the next editor.
+A failed assertion does not stop the remaining probes. Each probe prints one
+`EDITOR_PROBE verdict=...` line with its class, property, and mismatches. Any failure makes the
+driver exit non-zero.
+
+The checked-in manifests cover:
+
+- `platformer-2d.json`: Player2D, Gem2D, Door2D, JumpBoostCarrier.
+- `perf-test.json`: ParticleRain.
+- `itest.json`: AutoSyncPlayerNode, InspectorPrimaryNode, InspectorTupleNode,
+  InspectorNativeNode, TestMovementComponent, AttachCarrier.
+
+Gem2D and ParticleRain have no exported fields of their own. Their probes edit the inherited
+`editor_description`. The itest manifest checks the RANGE hint on `speed`, ENUM hints, and
+the help description for `InspectorPrimaryNode.label`.
+
+## Results and cleanup
+
+Read the PNGs and inspect the Inspector panel. Each probe captures `1-default.png`,
+`2-edited.png`, and `3-reloaded.png`. Description probes also capture `4-help.png`.
+Captures use the editor viewport. `RenderingServer.force_draw()` is required because an idle
+editor does not redraw; waiting on `frame_post_draw` can hang.
+
+Exit codes: 0 all probes passed, 2 configuration or driver error, 3 missing class,
+4 assertion or capture failure, 5 timeout or incomplete editor run. Across projects the
+highest failure code wins. `EDITOR_PROBE_TIMEOUT` sets seconds per project, default 240.
+`EDITOR_PROBE_LOG` sets the combined editor log, default `/tmp/editor-probe.log`.
+
+The temporary scene is `res://scenes/editor_probe.tscn`. Cleanup restores `project.godot`
+from its backup and deletes the temporary plugin, scene, and scene's `.uid`. The driver
+refuses to overwrite those temporary paths if they already exist.
+
+Godot rewrites `*.import` files on editor startup. Cleanup checks `git status` under the
+project and runs `git checkout --` only for modified imports that were clean before the run.
+It restores pre-existing import edits from separate backups. Other project edits survive.
+After a run started from a clean project, verify `git status --short -- <project dir>` is empty.
+
+Godot can crash during GDExtension shutdown after printing results. Complete probe verdicts
+remain authoritative in that case. Missing verdicts or a timeout fail the run.

--- a/.claude/skills/editor-probe/manifests/itest.json
+++ b/.claude/skills/editor-probe/manifests/itest.json
@@ -1,0 +1,81 @@
+[
+  {
+    "project": "itest/godot",
+    "class": "AutoSyncPlayerNode",
+    "property": "speed",
+    "value": 500.0,
+    "expect": {
+      "type": "FLOAT",
+      "hint": "RANGE",
+      "hint_string": "0,1000,1",
+      "default": 250.0
+    },
+    "shots": "/tmp/editor-probe/AutoSyncPlayerNode"
+  },
+  {
+    "project": "itest/godot",
+    "class": "InspectorPrimaryNode",
+    "property": "label",
+    "value": "Knife",
+    "expect": {
+      "type": "STRING",
+      "hint": "ENUM",
+      "hint_string": "Hands,Knife",
+      "default": "Hands",
+      "description": "Primary kind description"
+    },
+    "shots": "/tmp/editor-probe/InspectorPrimaryNode"
+  },
+  {
+    "project": "itest/godot",
+    "class": "InspectorTupleNode",
+    "property": "value1",
+    "value": "Knife",
+    "expect": {
+      "type": "STRING",
+      "hint": "ENUM",
+      "hint_string": "Hands,Knife",
+      "default": "Hands"
+    },
+    "shots": "/tmp/editor-probe/InspectorTupleNode"
+  },
+  {
+    "project": "itest/godot",
+    "class": "InspectorNativeNode",
+    "property": "kind",
+    "value": "Knife",
+    "expect": {
+      "type": "STRING",
+      "hint": "ENUM",
+      "hint_string": "Hands,Knife",
+      "default": "Hands"
+    },
+    "shots": "/tmp/editor-probe/InspectorNativeNode"
+  },
+  {
+    "project": "itest/godot",
+    "class": "TestMovementComponent",
+    "property": "max_speed",
+    "value": 90.0,
+    "expect": {
+      "type": "FLOAT",
+      "hint": "NONE",
+      "hint_string": "",
+      "default": 0.0
+    },
+    "shots": "/tmp/editor-probe/TestMovementComponent"
+  },
+  {
+    "project": "itest/godot",
+    "class": "AttachCarrier",
+    "property": "value",
+    "value": 42,
+    "expect": {
+      "type": "INT",
+      "hint": "NONE",
+      "hint_string": "",
+      "default": 0
+    },
+    "shots": "/tmp/editor-probe/AttachCarrier"
+  }
+]

--- a/.claude/skills/editor-probe/manifests/perf-test.json
+++ b/.claude/skills/editor-probe/manifests/perf-test.json
@@ -1,0 +1,15 @@
+[
+  {
+    "project": "examples/perf-test/godot",
+    "class": "ParticleRain",
+    "property": "editor_description",
+    "value": "editor probe",
+    "expect": {
+      "type": "STRING",
+      "hint": "MULTILINE_TEXT",
+      "hint_string": "",
+      "default": ""
+    },
+    "shots": "/tmp/editor-probe/ParticleRain"
+  }
+]

--- a/.claude/skills/editor-probe/manifests/platformer-2d.json
+++ b/.claude/skills/editor-probe/manifests/platformer-2d.json
@@ -1,0 +1,54 @@
+[
+  {
+    "project": "examples/platformer-2d/godot",
+    "class": "Player2D",
+    "property": "speed",
+    "value": 300.0,
+    "expect": {
+      "type": "FLOAT",
+      "hint": "NONE",
+      "hint_string": "",
+      "default": 250.0
+    },
+    "shots": "/tmp/editor-probe/Player2D"
+  },
+  {
+    "project": "examples/platformer-2d/godot",
+    "class": "Gem2D",
+    "property": "editor_description",
+    "value": "editor probe",
+    "expect": {
+      "type": "STRING",
+      "hint": "MULTILINE_TEXT",
+      "hint_string": "",
+      "default": ""
+    },
+    "shots": "/tmp/editor-probe/Gem2D"
+  },
+  {
+    "project": "examples/platformer-2d/godot",
+    "class": "Door2D",
+    "property": "level_id",
+    "value": "Level2",
+    "expect": {
+      "type": "STRING",
+      "hint": "ENUM",
+      "hint_string": "Level1,Level2,Level3",
+      "default": "Level1"
+    },
+    "shots": "/tmp/editor-probe/Door2D"
+  },
+  {
+    "project": "examples/platformer-2d/godot",
+    "class": "JumpBoostCarrier",
+    "property": "multiplier",
+    "value": 3.0,
+    "expect": {
+      "type": "FLOAT",
+      "hint": "NONE",
+      "hint_string": "",
+      "default": 1.5
+    },
+    "shots": "/tmp/editor-probe/JumpBoostCarrier"
+  }
+]

--- a/.claude/skills/editor-probe/scripts/plugin.gd
+++ b/.claude/skills/editor-probe/scripts/plugin.gd
@@ -4,10 +4,103 @@ extends EditorPlugin
 const CONFIG := "res://addons/editor_probe/probe.json"
 const SCENE := "res://scenes/editor_probe.tscn"
 
-var cfg := {}
+const TYPE_NAMES := {
+	TYPE_NIL: "NIL",
+	TYPE_BOOL: "BOOL",
+	TYPE_INT: "INT",
+	TYPE_FLOAT: "FLOAT",
+	TYPE_STRING: "STRING",
+	TYPE_VECTOR2: "VECTOR2",
+	TYPE_VECTOR2I: "VECTOR2I",
+	TYPE_RECT2: "RECT2",
+	TYPE_RECT2I: "RECT2I",
+	TYPE_VECTOR3: "VECTOR3",
+	TYPE_VECTOR3I: "VECTOR3I",
+	TYPE_TRANSFORM2D: "TRANSFORM2D",
+	TYPE_VECTOR4: "VECTOR4",
+	TYPE_VECTOR4I: "VECTOR4I",
+	TYPE_PLANE: "PLANE",
+	TYPE_QUATERNION: "QUATERNION",
+	TYPE_AABB: "AABB",
+	TYPE_BASIS: "BASIS",
+	TYPE_TRANSFORM3D: "TRANSFORM3D",
+	TYPE_PROJECTION: "PROJECTION",
+	TYPE_COLOR: "COLOR",
+	TYPE_STRING_NAME: "STRING_NAME",
+	TYPE_NODE_PATH: "NODE_PATH",
+	TYPE_RID: "RID",
+	TYPE_OBJECT: "OBJECT",
+	TYPE_CALLABLE: "CALLABLE",
+	TYPE_SIGNAL: "SIGNAL",
+	TYPE_DICTIONARY: "DICTIONARY",
+	TYPE_ARRAY: "ARRAY",
+	TYPE_PACKED_BYTE_ARRAY: "PACKED_BYTE_ARRAY",
+	TYPE_PACKED_INT32_ARRAY: "PACKED_INT32_ARRAY",
+	TYPE_PACKED_INT64_ARRAY: "PACKED_INT64_ARRAY",
+	TYPE_PACKED_FLOAT32_ARRAY: "PACKED_FLOAT32_ARRAY",
+	TYPE_PACKED_FLOAT64_ARRAY: "PACKED_FLOAT64_ARRAY",
+	TYPE_PACKED_STRING_ARRAY: "PACKED_STRING_ARRAY",
+	TYPE_PACKED_VECTOR2_ARRAY: "PACKED_VECTOR2_ARRAY",
+	TYPE_PACKED_VECTOR3_ARRAY: "PACKED_VECTOR3_ARRAY",
+	TYPE_PACKED_COLOR_ARRAY: "PACKED_COLOR_ARRAY",
+	TYPE_PACKED_VECTOR4_ARRAY: "PACKED_VECTOR4_ARRAY",
+	TYPE_MAX: "MAX",
+}
+
+const HINT_NAMES := {
+	PROPERTY_HINT_NONE: "NONE",
+	PROPERTY_HINT_RANGE: "RANGE",
+	PROPERTY_HINT_ENUM: "ENUM",
+	PROPERTY_HINT_ENUM_SUGGESTION: "ENUM_SUGGESTION",
+	PROPERTY_HINT_EXP_EASING: "EXP_EASING",
+	PROPERTY_HINT_LINK: "LINK",
+	PROPERTY_HINT_FLAGS: "FLAGS",
+	PROPERTY_HINT_LAYERS_2D_RENDER: "LAYERS_2D_RENDER",
+	PROPERTY_HINT_LAYERS_2D_PHYSICS: "LAYERS_2D_PHYSICS",
+	PROPERTY_HINT_LAYERS_2D_NAVIGATION: "LAYERS_2D_NAVIGATION",
+	PROPERTY_HINT_LAYERS_3D_RENDER: "LAYERS_3D_RENDER",
+	PROPERTY_HINT_LAYERS_3D_PHYSICS: "LAYERS_3D_PHYSICS",
+	PROPERTY_HINT_LAYERS_3D_NAVIGATION: "LAYERS_3D_NAVIGATION",
+	PROPERTY_HINT_LAYERS_AVOIDANCE: "LAYERS_AVOIDANCE",
+	PROPERTY_HINT_FILE: "FILE",
+	PROPERTY_HINT_DIR: "DIR",
+	PROPERTY_HINT_GLOBAL_FILE: "GLOBAL_FILE",
+	PROPERTY_HINT_GLOBAL_DIR: "GLOBAL_DIR",
+	PROPERTY_HINT_RESOURCE_TYPE: "RESOURCE_TYPE",
+	PROPERTY_HINT_MULTILINE_TEXT: "MULTILINE_TEXT",
+	PROPERTY_HINT_EXPRESSION: "EXPRESSION",
+	PROPERTY_HINT_PLACEHOLDER_TEXT: "PLACEHOLDER_TEXT",
+	PROPERTY_HINT_COLOR_NO_ALPHA: "COLOR_NO_ALPHA",
+	PROPERTY_HINT_OBJECT_ID: "OBJECT_ID",
+	PROPERTY_HINT_TYPE_STRING: "TYPE_STRING",
+	PROPERTY_HINT_NODE_PATH_TO_EDITED_NODE: "NODE_PATH_TO_EDITED_NODE",
+	PROPERTY_HINT_OBJECT_TOO_BIG: "OBJECT_TOO_BIG",
+	PROPERTY_HINT_NODE_PATH_VALID_TYPES: "NODE_PATH_VALID_TYPES",
+	PROPERTY_HINT_SAVE_FILE: "SAVE_FILE",
+	PROPERTY_HINT_GLOBAL_SAVE_FILE: "GLOBAL_SAVE_FILE",
+	PROPERTY_HINT_INT_IS_OBJECTID: "INT_IS_OBJECTID",
+	PROPERTY_HINT_INT_IS_POINTER: "INT_IS_POINTER",
+	PROPERTY_HINT_ARRAY_TYPE: "ARRAY_TYPE",
+	PROPERTY_HINT_DICTIONARY_TYPE: "DICTIONARY_TYPE",
+	PROPERTY_HINT_LOCALE_ID: "LOCALE_ID",
+	PROPERTY_HINT_LOCALIZABLE_STRING: "LOCALIZABLE_STRING",
+	PROPERTY_HINT_NODE_TYPE: "NODE_TYPE",
+	PROPERTY_HINT_HIDE_QUATERNION_EDIT: "HIDE_QUATERNION_EDIT",
+	PROPERTY_HINT_PASSWORD: "PASSWORD",
+	PROPERTY_HINT_TOOL_BUTTON: "TOOL_BUTTON",
+	PROPERTY_HINT_ONESHOT: "ONESHOT",
+	PROPERTY_HINT_GROUP_ENABLE: "GROUP_ENABLE",
+	PROPERTY_HINT_INPUT_NAME: "INPUT_NAME",
+	PROPERTY_HINT_FILE_PATH: "FILE_PATH",
+	PROPERTY_HINT_MAX: "MAX",
+}
+
+var probes: Array = []
+var cfg: Dictionary = {}
+var mismatches: Array[String] = []
 
 func _enter_tree() -> void:
-	cfg = JSON.parse_string(FileAccess.get_file_as_string(CONFIG))
+	probes = JSON.parse_string(FileAccess.get_file_as_string(CONFIG))
 	_run.call_deferred()
 
 func _settle(frames: int = 30) -> void:
@@ -15,59 +108,134 @@ func _settle(frames: int = 30) -> void:
 		await get_tree().process_frame
 
 func _shot(name: String) -> void:
+	# The idle editor does not redraw without input.
 	RenderingServer.force_draw()
 	var image := EditorInterface.get_base_control().get_viewport().get_texture().get_image()
 	DirAccess.make_dir_recursive_absolute(cfg["shots"])
 	var path: String = cfg["shots"].path_join("%s.png" % name)
-	image.save_png(path)
+	var error := image.save_png(path)
+	if error != OK:
+		mismatches.append("screenshot %s: %s" % [name, error_string(error)])
 	print("EDITOR_PROBE shot=", path)
 
 func _probe_node() -> Node:
 	return EditorInterface.get_edited_scene_root().get_node(cfg.get("node_name", "Probe"))
 
-func _run() -> void:
-	await _settle()
-	var cls: String = cfg["class"]
-	print("EDITOR_PROBE class_exists=", ClassDB.class_exists(cls))
-	if not ClassDB.class_exists(cls):
-		get_tree().quit(3)
-		return
+func _check(key: String, actual: Variant, expected: Variant) -> void:
+	var numeric := (actual is int or actual is float) and (expected is int or expected is float)
+	if (typeof(actual) != typeof(expected) and not numeric) or actual != expected:
+		mismatches.append("%s expected=%s actual=%s" % [key, JSON.stringify(expected), JSON.stringify(actual)])
 
+func _check_properties(node: Node) -> bool:
+	var property: String = cfg["property"]
+	var entry: Dictionary = {}
+	for item in node.get_property_list():
+		if item["name"] == property:
+			entry = item
+			break
+	if entry.is_empty():
+		mismatches.append("property %s missing from get_property_list()" % property)
+		return false
+	var expect: Dictionary = cfg.get("expect", {})
+	if expect.has("type"):
+		_check("expect.type", TYPE_NAMES.get(entry["type"], str(entry["type"])), expect["type"])
+	if expect.has("hint"):
+		_check("expect.hint", HINT_NAMES.get(entry["hint"], str(entry["hint"])), expect["hint"])
+	if expect.has("hint_string"):
+		_check("expect.hint_string", entry["hint_string"], expect["hint_string"])
+	if expect.has("default"):
+		_check("expect.default", node.get(property), expect["default"])
+	return true
+
+func _help_label() -> RichTextLabel:
+	var script_editor := EditorInterface.get_script_editor()
+	for help in script_editor.find_children("*", "EditorHelp", true, false):
+		if not help.is_visible_in_tree():
+			continue
+		for child in help.get_children():
+			if child is RichTextLabel and child.is_visible_in_tree():
+				return child
+	return null
+
+func _check_help() -> void:
+	var version := Engine.get_version_info()
+	if version["major"] != 4 or version["minor"] != 6:
+		mismatches.append("expect.description requires Godot 4.6 help controls; got %s" % version["string"])
+		return
+	EditorInterface.set_main_screen_editor("Script")
+	EditorInterface.get_script_editor().goto_help("class_property:%s:%s" % [cfg["class"], cfg["property"]])
+	await _settle()
+	var label := _help_label()
+	if label == null:
+		mismatches.append("expect.description: Godot 4.6 visible EditorHelp/RichTextLabel not found under ScriptEditor; build with godot-bevy/register-docs")
+	else:
+		var description: String = cfg["expect"]["description"]
+		if not label.get_parsed_text().contains(description):
+			mismatches.append("expect.description missing %s in editor help; build with godot-bevy/register-docs" % JSON.stringify(description))
+	_shot("4-help")
+
+func _probe() -> int:
+	var cls: String = cfg["class"]
+	if not ClassDB.class_exists(cls):
+		mismatches.append("class does not exist in the editor")
+		return 3
 	var root: Node = ClassDB.instantiate(cfg.get("root", "Node2D"))
 	root.name = "EditorProbe"
 	var node: Node = ClassDB.instantiate(cls)
 	node.name = cfg.get("node_name", "Probe")
 	root.add_child(node)
 	node.owner = root
+	var found := _check_properties(node)
+	if not found:
+		root.free()
+		return 4
 	var packed := PackedScene.new()
-	packed.pack(root)
-	ResourceSaver.save(packed, SCENE)
+	var error := packed.pack(root)
+	if error == OK:
+		error = ResourceSaver.save(packed, SCENE)
 	root.free()
+	if error != OK:
+		mismatches.append("save initial scene: %s" % error_string(error))
+		return 4
 
 	EditorInterface.open_scene_from_path(SCENE)
+	EditorInterface.reload_scene_from_path(SCENE)
 	await _settle()
 	var property: String = cfg["property"]
 	var edited := _probe_node()
-	print("EDITOR_PROBE default ", property, "=", edited.get(property))
 	EditorInterface.edit_node(edited)
 	await _settle(10)
-	await _shot("1-default")
+	_shot("1-default")
 
 	edited.set(property, cfg["value"])
 	EditorInterface.edit_node(edited)
 	await _settle(10)
-	await _shot("2-edited")
+	_shot("2-edited")
 
-	EditorInterface.save_scene()
+	error = EditorInterface.save_scene()
+	if error != OK:
+		mismatches.append("save edited scene: %s" % error_string(error))
 	await _settle(10)
 	EditorInterface.reload_scene_from_path(SCENE)
 	await _settle()
 	var reloaded := _probe_node()
-	var value = reloaded.get(property)
-	print("EDITOR_PROBE reloaded ", property, "=", value)
+	_check("reload", reloaded.get(property), cfg["value"])
 	EditorInterface.edit_node(reloaded)
 	await _settle(10)
-	await _shot("3-reloaded")
-	var verdict := 0 if str(value) == str(cfg["value"]) else 4
-	print("EDITOR_PROBE verdict=", verdict)
-	get_tree().quit(verdict)
+	_shot("3-reloaded")
+	if cfg.get("expect", {}).has("description"):
+		await _check_help()
+	return 0 if mismatches.is_empty() else 4
+
+func _run() -> void:
+	await _settle()
+	var status := 0
+	for probe in probes:
+		cfg = probe
+		mismatches = []
+		var verdict := await _probe()
+		print("EDITOR_PROBE verdict=%s class=%s property=%s mismatches=%s" % [
+			verdict, cfg["class"], cfg["property"], JSON.stringify(mismatches)])
+		status = maxi(status, verdict)
+	print("EDITOR_PROBE complete")
+	get_tree().quit(status)

--- a/.claude/skills/editor-probe/scripts/run.sh
+++ b/.claude/skills/editor-probe/scripts/run.sh
@@ -1,62 +1,174 @@
 #!/bin/bash
-# usage: run.sh <godot project dir> <probe.json>
-# Launches the Godot editor on the project with a temporary probe plugin, prints the probe's
-# output, restores the project, and exits with the probe's verdict.
-set -u
-PROJ="$(cd "$1" && pwd)"
-CFG="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
-HERE="$(cd "$(dirname "$0")" && pwd)"
-GODOT="${GODOT4_BIN:-godot}"
-TIMEOUT="${EDITOR_PROBE_TIMEOUT:-240}"
-LOG="${EDITOR_PROBE_LOG:-/tmp/editor-probe.log}"
-ADDON="$PROJ/addons/editor_probe"
-PROBE_SCENE="$PROJ/scenes/editor_probe.tscn"
-BACKUP="$(mktemp)"
+set -euo pipefail
+exec python3 - "$0" "$@" <<'DRIVER'
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
 
-cleanup() {
-    cp "$BACKUP" "$PROJ/project.godot"
-    rm -f "$BACKUP"
-    rm -rf "$ADDON" "$PROBE_SCENE" "$PROBE_SCENE.uid"
-    git -C "$PROJ" checkout -- . 2>/dev/null
-}
-trap cleanup EXIT
+here = Path(sys.argv[1]).resolve().parent
+repo = here.parents[3]
+godot = os.environ.get("GODOT4_BIN", "godot")
+timeout = int(os.environ.get("EDITOR_PROBE_TIMEOUT", "240"))
+log_path = Path(os.environ.get("EDITOR_PROBE_LOG", "/tmp/editor-probe.log"))
 
-cp "$PROJ/project.godot" "$BACKUP"
-mkdir -p "$ADDON" "$PROJ/scenes"
-cp "$HERE/plugin.gd" "$ADDON/plugin.gd"
-cp "$CFG" "$ADDON/probe.json"
-printf '[plugin]\n\nname="editor_probe"\ndescription="temporary editor probe"\nauthor="editor-probe skill"\nversion="0"\nscript="plugin.gd"\n' > "$ADDON/plugin.cfg"
-python3 - "$PROJ/project.godot" <<'EOF'
-import re, sys
-path = sys.argv[1]
-text = open(path).read()
-entry = '"res://addons/editor_probe/plugin.cfg"'
-match = re.search(r'enabled=PackedStringArray\((.*?)\)', text)
-if match:
-    inner = match.group(1).strip()
-    new = entry if not inner else f"{inner}, {entry}"
-    text = text[:match.start(1)] + new + text[match.end(1):]
-else:
-    text += f"\n[editor_plugins]\n\nenabled=PackedStringArray({entry})\n"
-open(path, "w").write(text)
-EOF
 
-: > "$LOG"
-"$GODOT" --editor --path "$PROJ" > "$LOG" 2>&1 &
-pid=$!
-for _ in $(seq 1 "$TIMEOUT"); do
-    kill -0 "$pid" 2>/dev/null || break
-    sleep 1
-done
-if kill -0 "$pid" 2>/dev/null; then
-    kill "$pid"
-    wait "$pid" 2>/dev/null
-    echo "editor-probe: timed out after ${TIMEOUT}s" >&2
-    grep -E "EDITOR_PROBE" "$LOG"
-    exit 5
-fi
-wait "$pid"
-status=$?
-grep -E "EDITOR_PROBE" "$LOG"
-verdict=$(sed -n 's/^EDITOR_PROBE verdict=//p' "$LOG" | tail -1)
-exit "${verdict:-$status}"
+def import_status(project):
+    status = subprocess.check_output([
+        "git", "-C", str(project), "status", "--porcelain=v1", "-z",
+        "--untracked-files=all", "--", "*.import",
+    ])
+    entries = iter(status.split(b"\0"))
+    paths = {}
+    for entry in entries:
+        if not entry:
+            continue
+        paths[repo / os.fsdecode(entry[3:])] = entry[:2]
+        if b"R" in entry[:2] or b"C" in entry[:2]:
+            next(entries)
+    return paths
+
+
+def stop(editor):
+    if editor is not None and editor.poll() is None:
+        editor.terminate()
+        try:
+            editor.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            editor.kill()
+            editor.wait()
+
+
+def run_project(project, probes, log):
+    addon = project / "addons/editor_probe"
+    scene = project / "scenes/editor_probe.tscn"
+    scene_uid = scene.with_suffix(".tscn.uid")
+    for path in (addon, scene, scene_uid):
+        if path.exists() or path.is_symlink():
+            raise ValueError(f"temporary probe path already exists: {path}")
+    project_file = project / "project.godot"
+    imports = {path: path.read_bytes() if path.is_file() else None
+               for path in import_status(project)}
+    editor = None
+    with tempfile.TemporaryDirectory(prefix="editor-probe-") as temporary:
+        backup = Path(temporary) / "project.godot"
+        shutil.copy2(project_file, backup)
+        try:
+            addon.mkdir(parents=True)
+            scene.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(here / "plugin.gd", addon / "plugin.gd")
+            (addon / "probe.json").write_text(json.dumps(probes))
+            (addon / "plugin.cfg").write_text(
+                '[plugin]\nname="editor_probe"\ndescription="temporary editor probe"\n'
+                'author="editor-probe skill"\nversion="0"\nscript="plugin.gd"\n'
+            )
+            text = project_file.read_text()
+            entry = '"res://addons/editor_probe/plugin.cfg"'
+            section = re.search(r"(?ms)^\[editor_plugins\]\s*\n(.*?)(?=^\[|\Z)", text)
+            if section:
+                settings = section.group(1)
+                enabled = re.search(r"enabled=PackedStringArray\((.*?)\)", settings, re.S)
+                if enabled:
+                    inner = enabled.group(1).strip()
+                    settings = (settings[:enabled.start(1)]
+                                + (f"{inner}, {entry}" if inner else entry)
+                                + settings[enabled.end(1):])
+                else:
+                    settings += f"enabled=PackedStringArray({entry})\n"
+                text = text[:section.start(1)] + settings + text[section.end(1):]
+            else:
+                text += f"\n[editor_plugins]\n\nenabled=PackedStringArray({entry})\n"
+            project_file.write_text(text)
+            offset = log.tell()
+            print(f"editor-probe: project={project.relative_to(repo)} probes={len(probes)}", flush=True)
+            editor = subprocess.Popen([godot, "--editor", "--path", str(project)],
+                                      stdout=log, stderr=subprocess.STDOUT)
+            timed_out = False
+            try:
+                editor.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                stop(editor)
+            log.seek(offset)
+            output = log.read()
+            log.seek(0, os.SEEK_END)
+            verdicts = re.findall(r"^EDITOR_PROBE verdict=(\d+) .*", output, re.M)
+            for line in output.splitlines():
+                if line.startswith("EDITOR_PROBE"):
+                    print(line)
+            reason = (f"editor timed out after {timeout}s" if timed_out else
+                      f"editor exited with status {editor.returncode} before completing probes; see {log_path}")
+            for probe in probes[len(verdicts):]:
+                print(f"EDITOR_PROBE verdict=5 class={probe['class']} "
+                      f"property={probe['property']} mismatches={json.dumps([reason])}")
+            if timed_out or len(verdicts) != len(probes) or "EDITOR_PROBE complete" not in output:
+                print(f"editor-probe: {reason}", file=sys.stderr)
+                return 5
+            return max(map(int, verdicts))
+        finally:
+            stop(editor)
+            shutil.copy2(backup, project_file)
+            shutil.rmtree(addon, ignore_errors=True)
+            scene.unlink(missing_ok=True)
+            scene_uid.unlink(missing_ok=True)
+            changed = [str(path.relative_to(repo)) for path, status in import_status(project).items()
+                       if status[1:2] == b"M" and path not in imports]
+            if changed:
+                subprocess.run(["git", "-C", str(repo), "checkout", "--", *changed], check=True)
+            for path, data in imports.items():
+                if data is None:
+                    path.unlink(missing_ok=True)
+                else:
+                    path.write_bytes(data)
+
+
+def main():
+    args = sys.argv[2:]
+    if len(args) != 2:
+        raise ValueError("usage: run.sh <project dir> <probe.json> | run.sh --manifest <file>")
+    config = json.loads(Path(args[1]).read_text())
+    if args[0] == "--manifest":
+        if not isinstance(config, list) or not config:
+            raise ValueError("manifest must be a non-empty JSON list of probes")
+        probes = config
+    else:
+        probes = [dict(config, project=str(Path(args[0]).resolve().relative_to(repo)))]
+    projects = {}
+    for probe in probes:
+        for key in ("project", "class", "property", "shots"):
+            if not isinstance(probe.get(key), str) or not probe[key]:
+                raise ValueError(f"probe requires a non-empty {key}: {probe}")
+        if "value" not in probe or not isinstance(probe.get("expect", {}), dict):
+            raise ValueError(f"probe requires value and expect must be an object: {probe}")
+        project = (repo / probe["project"]).resolve()
+        if Path(probe["project"]).is_absolute() or not project.is_relative_to(repo):
+            raise ValueError(f"project must be relative to the repo root: {probe['project']}")
+        if not (project / "project.godot").is_file():
+            raise ValueError(f"missing project.godot: {project}")
+        projects.setdefault(project, []).append(probe)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    result = 0
+    with log_path.open("w+") as log:
+        for project, probes in projects.items():
+            result = max(result, run_project(project, probes, log))
+    return result
+
+
+def interrupted(signum, frame):
+    raise KeyboardInterrupt
+
+
+signal.signal(signal.SIGTERM, interrupted)
+try:
+    sys.exit(main())
+except (OSError, ValueError, subprocess.CalledProcessError) as error:
+    print(f"editor-probe: {error}", file=sys.stderr)
+    sys.exit(2)
+except KeyboardInterrupt:
+    sys.exit(130)
+DRIVER


### PR DESCRIPTION
Follow-up to the editor-probe skill from #265, so it covers more than one class.

`run.sh --manifest <file>` sweeps a list of probes, one editor launch per project, one verdict line per probe. Each probe can now assert what `get_property_list()` reports for the property: `type`, `hint`, `hint_string`, `default`, so a RANGE or ENUM hint is checked as data as well as shown in the capture. With `expect.description` and the crate built with `register-docs`, it opens the editor help for the property and asserts the text is there, captured as `4-help.png`. Cleanup no longer does a blanket `git checkout` on the project; it restores `project.godot`, removes the probe plugin and scene, and reverts only the `.import` files the editor rewrote, so uncommitted edits in the project survive a run (tested).

Three manifests are checked in: platformer-2d (Player2D, Gem2D, Door2D, JumpBoostCarrier), perf-test (ParticleRain), and itest (AutoSyncPlayerNode with its RANGE hint, InspectorPrimaryNode with the ENUM hint and its registered description, InspectorTupleNode, InspectorNativeNode, TestMovementComponent, AttachCarrier). The platformer and itest sweeps pass on main; negative probes with a wrong hint, wrong default, or missing description fail on exactly that mismatch.

No Rust changes. The driver is Python inside the bash entry point; it needs only python3 and `godot` on PATH.
