### PR TITLE
editor-probe: missing node is a mismatch, inputs are validated

### DIFF
--- a/.claude/skills/editor-probe/scripts/plugin.gd
+++ b/.claude/skills/editor-probe/scripts/plugin.gd
@@ -119,7 +119,12 @@ func _shot(name: String) -> void:
 	print("EDITOR_PROBE shot=", path)
 
 func _probe_node() -> Node:
-	return EditorInterface.get_edited_scene_root().get_node(cfg.get("node_name", "Probe"))
+	var root := EditorInterface.get_edited_scene_root()
+	var name: String = cfg.get("node_name", "Probe")
+	var node := root.get_node_or_null(name) if root else null
+	if node == null:
+		mismatches.append("node %s not found in the edited scene" % name)
+	return node
 
 func _check(key: String, actual: Variant, expected: Variant) -> void:
 	var numeric := (actual is int or actual is float) and (expected is int or expected is float)
@@ -203,6 +208,8 @@ func _probe() -> int:
 	await _settle()
 	var property: String = cfg["property"]
 	var edited := _probe_node()
+	if edited == null:
+		return 4
 	EditorInterface.edit_node(edited)
 	await _settle(10)
 	_shot("1-default")
@@ -219,6 +226,8 @@ func _probe() -> int:
 	EditorInterface.reload_scene_from_path(SCENE)
 	await _settle()
 	var reloaded := _probe_node()
+	if reloaded == null:
+		return 4
 	_check("reload", reloaded.get(property), cfg["value"])
 	EditorInterface.edit_node(reloaded)
 	await _settle(10)

--- a/.claude/skills/editor-probe/scripts/run.sh
+++ b/.claude/skills/editor-probe/scripts/run.sh
@@ -137,14 +137,20 @@ def main():
             raise ValueError("manifest must be a non-empty JSON list of probes")
         probes = config
     else:
+        if not isinstance(config, dict):
+            raise ValueError("probe.json must be a JSON object")
         probes = [dict(config, project=str(Path(args[0]).resolve().relative_to(repo)))]
     projects = {}
     for probe in probes:
+        if not isinstance(probe, dict):
+            raise ValueError(f"probe must be a JSON object: {probe}")
         for key in ("project", "class", "property", "shots"):
             if not isinstance(probe.get(key), str) or not probe[key]:
                 raise ValueError(f"probe requires a non-empty {key}: {probe}")
         if "value" not in probe or not isinstance(probe.get("expect", {}), dict):
             raise ValueError(f"probe requires value and expect must be an object: {probe}")
+        if not Path(probe["shots"]).is_absolute():
+            raise ValueError(f"shots must be an absolute path: {probe['shots']}")
         project = (repo / probe["project"]).resolve()
         if Path(probe["project"]).is_absolute() or not project.is_relative_to(repo):
             raise ValueError(f"project must be relative to the repo root: {probe['project']}")


### PR DESCRIPTION
Copilot's two points on #267, which landed before I got to them.

The plugin looked the probe node up with `get_node`, so a missing node aborted the editor session and every later probe in the manifest with it; it now uses `get_node_or_null`, records the miss as a mismatch, and moves on. The driver validates its inputs before touching the project: a single-probe config must be a JSON object, manifest entries must be objects, and `shots` must be absolute since the plugin creates it with `make_dir_recursive_absolute`. Malformed input exits 2 with the reason instead of a Python traceback.
